### PR TITLE
fix: update frontend baseURL to match backend route changes (removed …

### DIFF
--- a/src/hooks/useAPI.ts
+++ b/src/hooks/useAPI.ts
@@ -6,7 +6,7 @@ import { getAuthToken } from "../utils/auth";
  * @author Ankur Mundra on April, 2023
  */
 
-axios.defaults.baseURL = "http://localhost:3002/api/v1";
+axios.defaults.baseURL = "http://localhost:3002";
 axios.defaults.headers.common["Accept"] = "application/json";
 axios.defaults.headers.post["Content-Type"] = "application/json";
 axios.defaults.headers.put["Content-Type"] = "application/json";

--- a/src/utils/axios_client.ts
+++ b/src/utils/axios_client.ts
@@ -6,7 +6,7 @@ import { getAuthToken } from "./auth";
  */
 
 const axiosClient = axios.create({
-  baseURL: "http://localhost:3002/api/v1",
+  baseURL: "http://localhost:3002",
   timeout: 1000,
   headers: {
     "Content-Type": "application/json",


### PR DESCRIPTION
This PR fixes the frontend routing error caused by outdated API base URLs.

After removing the /api/v1 namespace from backend controllers, the frontend was still making requests to /api/v1 endpoints, leading to routing issues.