### PR TITLE
E2567. Review rubrics varying by round

### DIFF
--- a/src/components/Form/FormCheckBox.tsx
+++ b/src/components/Form/FormCheckBox.tsx
@@ -28,6 +28,7 @@ const FormCheckbox: React.FC<IFormProps> = (props) => {
             <InputGroup>
               <Form.Check
                 {...field}
+                checked={field.value}
                 className="mx-md-2"
                 type="checkbox"
                 disabled={disabled}

--- a/src/pages/Assignments/AssignmentEditor.test.tsx
+++ b/src/pages/Assignments/AssignmentEditor.test.tsx
@@ -1,0 +1,197 @@
+import React from "react";
+import { render, screen, within } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { vi, beforeEach, describe, expect, it } from "vitest";
+import AssignmentEditor from "./AssignmentEditor";
+import { transformAssignmentRequest, IAssignmentFormValues } from "./AssignmentUtil";
+
+// Mock useAPI to avoid real network calls
+const sendRequestMock = vi.fn();
+vi.mock("../../hooks/useAPI", () => {
+  return {
+    __esModule: true,
+    default: () => ({
+      data: null,
+      error: null,
+      sendRequest: sendRequestMock,
+    }),
+  };
+});
+
+// Provide minimal redux wiring
+const dispatchMock = vi.fn();
+vi.mock("react-redux", () => ({
+  useDispatch: () => dispatchMock,
+  useSelector: (selector: any) => selector({ authentication: { isAuthenticated: true } }),
+}));
+
+// Provide router context hooks
+let loaderData: any;
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<any>("react-router-dom");
+  return {
+    ...actual,
+    useLoaderData: () => loaderData,
+    useLocation: () => ({ state: {} }),
+    useNavigate: () => vi.fn(),
+  };
+});
+
+const baseAssignment = {
+  id: 1,
+  name: "Test Assignment",
+  review_rubric_varies_by_round: true,
+  number_of_review_rounds: 2,
+  assignment_questionnaires: [
+    { id: 10, used_in_round: 1, questionnaire: { id: 101, name: "Round 1 Rubric" } },
+    { id: 11, used_in_round: 2, questionnaire: { id: 102, name: "Round 2 Rubric" } },
+  ],
+  questionnaires: [
+    { id: 101, name: "Round 1 Rubric" },
+    { id: 102, name: "Round 2 Rubric" },
+    { id: 200, name: "Unlinked Rubric" },
+  ],
+  weights: [],
+};
+
+describe("AssignmentEditor rubrics tab", () => {
+  beforeEach(() => {
+    loaderData = { ...baseAssignment };
+    sendRequestMock.mockClear();
+    dispatchMock.mockClear();
+  });
+
+  it("shows one row per review round when rubrics vary by round", () => {
+    render(<AssignmentEditor mode="update" />);
+
+    expect(screen.getByText("Review round 1:")).toBeInTheDocument();
+    expect(screen.getByText("Review round 2:")).toBeInTheDocument();
+  });
+
+  it("shows a single rubric row when rubrics do not vary by round", () => {
+    loaderData = { ...baseAssignment, review_rubric_varies_by_round: false };
+
+    render(<AssignmentEditor mode="update" />);
+
+    expect(screen.getByText("Review rubric:")).toBeInTheDocument();
+    expect(screen.queryByText("Review round 2:")).not.toBeInTheDocument();
+  });
+
+  it("prefills the selected questionnaire per round from loader data", () => {
+    render(<AssignmentEditor mode="update" />);
+
+    const round1Row = screen.getByText("Review round 1:").closest("tr");
+    expect(round1Row).not.toBeNull();
+    const select = within(round1Row as HTMLElement).getByRole("combobox") as HTMLSelectElement;
+    expect(select.value).toBe("101");
+  });
+
+  it("lists all available questionnaires, including unlinked ones", () => {
+    render(<AssignmentEditor mode="update" />);
+
+    const allOptions = screen.getAllByRole("option").map((opt) => opt.textContent);
+    expect(allOptions).toContain("Unlinked Rubric");
+  });
+
+});
+
+describe("transformAssignmentRequest", () => {
+  it("builds assignment_questionnaires_attributes for selected rounds", () => {
+    const values: IAssignmentFormValues = {
+      id: 1,
+      name: "Test Assignment",
+      directory_path: "assignment_1",
+      spec_location: "http://example.com",
+      private: false,
+      show_template_review: false,
+      require_quiz: false,
+      has_badge: false,
+      staggered_deadline: false,
+      is_calibrated: false,
+      review_rubric_varies_by_round: true,
+      number_of_review_rounds: 2,
+      questionnaire_round_1: 101,
+      assignment_questionnaire_id_1: 10,
+      questionnaire_round_2: 102,
+      weights: [],
+      notification_limits: [],
+      use_date_updater: [],
+      submission_allowed: [],
+      review_allowed: [],
+      teammate_allowed: [],
+      metareview_allowed: [],
+      reminder: [],
+    };
+
+    const payload = JSON.parse(transformAssignmentRequest(values));
+
+    expect(payload.assignment.assignment_questionnaires_attributes).toEqual([
+      { id: 10, questionnaire_id: 101, used_in_round: 1 },
+      { questionnaire_id: 102, used_in_round: 2 },
+    ]);
+    expect(payload.assignment.vary_by_round).toBe(true);
+    expect(payload.assignment.rounds_of_reviews).toBe(2);
+  });
+
+  it("includes existing id when present and skips rounds without selection", () => {
+    const values: IAssignmentFormValues = {
+      id: 1,
+      name: "Test Assignment",
+      directory_path: "assignment_1",
+      spec_location: "http://example.com",
+      private: false,
+      show_template_review: false,
+      require_quiz: false,
+      has_badge: false,
+      staggered_deadline: false,
+      is_calibrated: false,
+      review_rubric_varies_by_round: true,
+      number_of_review_rounds: 2,
+      questionnaire_round_1: 201,
+      assignment_questionnaire_id_1: 99,
+      weights: [],
+      notification_limits: [],
+      use_date_updater: [],
+      submission_allowed: [],
+      review_allowed: [],
+      teammate_allowed: [],
+      metareview_allowed: [],
+      reminder: [],
+    };
+
+    const payload = JSON.parse(transformAssignmentRequest(values));
+
+    expect(payload.assignment.assignment_questionnaires_attributes).toEqual([
+      { id: 99, questionnaire_id: 201, used_in_round: 1 },
+    ]);
+  });
+
+  it("sets vary_by_round to false when checkbox is unchecked", () => {
+    const values: IAssignmentFormValues = {
+      id: 1,
+      name: "Test Assignment",
+      directory_path: "assignment_1",
+      spec_location: "http://example.com",
+      private: false,
+      show_template_review: false,
+      require_quiz: false,
+      has_badge: false,
+      staggered_deadline: false,
+      is_calibrated: false,
+      review_rubric_varies_by_round: false,
+      number_of_review_rounds: 1,
+      weights: [],
+      notification_limits: [],
+      use_date_updater: [],
+      submission_allowed: [],
+      review_allowed: [],
+      teammate_allowed: [],
+      metareview_allowed: [],
+      reminder: [],
+    };
+
+    const payload = JSON.parse(transformAssignmentRequest(values));
+
+    expect(payload.assignment.vary_by_round).toBe(false);
+  });
+});

--- a/src/pages/Assignments/AssignmentEditor.tsx
+++ b/src/pages/Assignments/AssignmentEditor.tsx
@@ -140,10 +140,10 @@ const AssignmentEditor = ({ mode }: { mode: "create" | "update" }) => {
     // validate sum of weights = 100%
     const totalWeight = values.weights?.reduce((acc: number, curr: number) => acc + curr, 0) || 0;
 
-    //if (totalWeight !== 100) {
-      //dispatch(alertActions.showAlert({ variant: "danger", message: "Sum of weights must be 100%" }));
-      //return;
-    //}
+    if (totalWeight !== 100) {
+      dispatch(alertActions.showAlert({ variant: "danger", message: "Sum of weights must be 100%" }));
+      return;
+    }
 
     let method: HttpMethod = HttpMethod.POST;
     let url: string = "/assignments";
@@ -172,14 +172,11 @@ const AssignmentEditor = ({ mode }: { mode: "create" | "update" }) => {
     }
   });
 
-  // Build dropdown options from the questionnaires already linked to this assignment
-  const questionnaireOptions = (assignmentData.assignment_questionnaires || [])
-    .map((aq: any) => aq.questionnaire)
-    .filter((q: any) => q)
-    .map((q: any) => ({ label: q.name, value: q.id }));
-
-  // Use the backend-computed review round count method (num_review_rounds) for existing assignments
-  const derivedReviewRounds = assignmentData.number_of_review_rounds;
+  // Build dropdown options from the questionnaires
+  const questionnaireOptions = (assignmentData.questionnaires || []).map((q: any) => ({
+    label: q.name,
+    value: q.id,
+  }));
 
   // Build initial form values from existing assignment data (update) or defaults (create)
   const formInitialValues: any = mode === "update" ? { ...assignmentData } : { ...initialValues };
@@ -301,9 +298,7 @@ const AssignmentEditor = ({ mode }: { mode: "create" | "update" }) => {
                     showPagination={false}
                     data={[
                       ...(() => {
-                        const rounds = (mode === "update" && formik.values.review_rubric_varies_by_round)
-                          ? derivedReviewRounds
-                          : (formik.values.number_of_review_rounds ?? 0);
+                        const rounds = formik.values.number_of_review_rounds ?? 0;
                         if (formik.values.review_rubric_varies_by_round) {
                           return Array.from({ length: rounds }, (_, i) => ([
                             {

--- a/src/pages/Assignments/AssignmentEditor.tsx
+++ b/src/pages/Assignments/AssignmentEditor.tsx
@@ -139,11 +139,11 @@ const AssignmentEditor = ({ mode }: { mode: "create" | "update" }) => {
 
     // validate sum of weights = 100%
     const totalWeight = values.weights?.reduce((acc: number, curr: number) => acc + curr, 0) || 0;
-    console.log(totalWeight);
-    if (totalWeight !== 100) {
-      dispatch(alertActions.showAlert({ variant: "danger", message: "Sum of weights must be 100%" }));
-      return;
-    }
+
+    //if (totalWeight !== 100) {
+      //dispatch(alertActions.showAlert({ variant: "danger", message: "Sum of weights must be 100%" }));
+      //return;
+    //}
 
     let method: HttpMethod = HttpMethod.POST;
     let url: string = "/assignments";

--- a/src/pages/Assignments/AssignmentEditor.tsx
+++ b/src/pages/Assignments/AssignmentEditor.tsx
@@ -178,6 +178,8 @@ const AssignmentEditor = ({ mode }: { mode: "create" | "update" }) => {
     value: q.id,
   }));
 
+  const reviewRounds = assignmentData.number_of_review_rounds;
+
   // Build initial form values from existing assignment data (update) or defaults (create)
   const formInitialValues: any = mode === "update" ? { ...assignmentData } : { ...initialValues };
   
@@ -298,7 +300,7 @@ const AssignmentEditor = ({ mode }: { mode: "create" | "update" }) => {
                     showPagination={false}
                     data={[
                       ...(() => {
-                        const rounds = formik.values.number_of_review_rounds ?? 0;
+                        const rounds = (mode == "update") ? reviewRounds ?? 0 : formik.values.number_of_review_rounds ?? 0;
                         if (formik.values.review_rubric_varies_by_round) {
                           return Array.from({ length: rounds }, (_, i) => ([
                             {

--- a/src/pages/Assignments/AssignmentUtil.ts
+++ b/src/pages/Assignments/AssignmentUtil.ts
@@ -105,7 +105,7 @@ export const transformAssignmentResponse = (assignmentResponse: string) => {
     has_badge: assignment.has_badge,
     staggered_deadline: assignment.staggered_deadline,
     is_calibrated: assignment.is_calibrated,
-    review_rubric_varies_by_round: assignment.vary_by_round,
+    review_rubric_varies_by_round: assignment.varying_rubrics_by_round ?? assignment.vary_by_round,
     number_of_review_rounds: assignment.num_review_rounds,
     due_dates: assignment.due_dates,
     assignment_questionnaires: assignment.assignment_questionnaires,
@@ -115,6 +115,8 @@ export const transformAssignmentResponse = (assignmentResponse: string) => {
 
 export async function loadAssignment({ params }: any) {
   let assignmentData = {};
+  let questionnaires = []; // fetch questionnaire list for dropdown window selections in Rubrics tab
+
   // if params contains id, then we are editing a user, so we need to load the user data
   if (params.id) {
     const userResponse = await axiosClient.get(`/assignments/${params.id}`, {
@@ -123,6 +125,8 @@ export async function loadAssignment({ params }: any) {
     assignmentData = await userResponse.data;
   }
 
-  return { ...assignmentData, weights: [] };
-}
+  const questionnairesRes = await axiosClient.get("/questionnaires");
+  questionnaires = questionnairesRes.data || [];
 
+  return { ...assignmentData, questionnaires, weights: [] };
+}

--- a/src/pages/Assignments/AssignmentUtil.ts
+++ b/src/pages/Assignments/AssignmentUtil.ts
@@ -78,7 +78,7 @@ export const transformAssignmentRequest = (values: IAssignmentFormValues) => {
     directory_path: values.directory_path,
     spec_location: values.spec_location,
     private: values.private,
-    show_template_review: values.show_template_review,
+    show_template_review: values.show_template_review ?? false,
     require_quiz: values.require_quiz,
     has_badge: values.has_badge,
     staggered_deadline: values.staggered_deadline,
@@ -89,7 +89,7 @@ export const transformAssignmentRequest = (values: IAssignmentFormValues) => {
 
   };
   console.log(assignment);
-  return JSON.stringify( { assignment } );
+  return JSON.stringify({ assignment });
 };
 
 export const transformAssignmentResponse = (assignmentResponse: string) => {
@@ -100,7 +100,7 @@ export const transformAssignmentResponse = (assignmentResponse: string) => {
     directory_path: assignment.directory_path,
     spec_location: assignment.spec_location,
     private: assignment.private,
-    show_template_review: assignment.show_template_review,
+    show_template_review: assignment.show_template_review ?? false,
     require_quiz: assignment.require_quiz,
     has_badge: assignment.has_badge,
     staggered_deadline: assignment.staggered_deadline,
@@ -123,6 +123,6 @@ export async function loadAssignment({ params }: any) {
     assignmentData = await userResponse.data;
   }
 
-  return assignmentData;
+  return { ...assignmentData, weights: [] };
 }
 

--- a/src/pages/Authentication/Login.tsx
+++ b/src/pages/Authentication/Login.tsx
@@ -30,7 +30,7 @@ const Login: React.FC = () => {
 
   const onSubmit = (values: ILoginFormValues, submitProps: FormikHelpers<ILoginFormValues>) => {
     axios
-      .post("http://152.7.177.187:3002/login", values)
+      .post("http://localhost:3002/login", values)
       .then((response) => {
         const payload = setAuthToken(response.data.token);
 

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -87,6 +87,16 @@ export interface IAssignmentRequest {
   has_badge:boolean,
   staggered_deadline:boolean,
   is_calibrated:boolean,
+  vary_by_round?: boolean,
+  rounds_of_reviews?: number,
+  assignment_questionnaires_attributes?: {
+    id?: number;
+    questionnaire_id: number;
+    used_in_round: number;
+    questionnaire_weight?: number;
+    notification_limit?: number;
+    _destroy?: boolean;
+  }[],
 }
 
 export interface ITAResponse {
@@ -170,6 +180,15 @@ export interface IAssignmentResponse {
   has_badge:boolean;
   staggered_deadline:boolean;
   is_calibrated:boolean;
+  vary_by_round?: boolean;
+  rounds_of_reviews?: number;
+  due_dates?: { id: number; deadline_type_id: number }[];
+  assignment_questionnaires?: {
+    id: number;
+    used_in_round?: number;
+    questionnaire?: { id: number; name: string };
+  }[];
+  num_review_rounds?: number;
   
 }
 
@@ -180,4 +199,3 @@ export const transformAssignmentResponse = (assignmentResponse: string): IAssign
   // Transform response as needed
   return assignment;
 };
-

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -181,6 +181,7 @@ export interface IAssignmentResponse {
   staggered_deadline:boolean;
   is_calibrated:boolean;
   vary_by_round?: boolean;
+  varying_rubrics_by_round?: boolean;
   rounds_of_reviews?: number;
   due_dates?: { id: number; deadline_type_id: number }[];
   assignment_questionnaires?: {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,23 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+      components: path.resolve(__dirname, "./src/components"),
+      utils: path.resolve(__dirname, "./src/utils"),
+    },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: "./src/setupTests.ts",
+  },
+});


### PR DESCRIPTION
While editing an assignment on the Rubrics tab, the number of review rows now comes from number of review due dates; if that isn’t available, it falls back to the “Number of review rounds” input on the Due dates tab when "Review rubric varies by round?" checkbox is checked.

On the Rubrics tab, prefill review-round dropdowns with currently used questionnaire, using assignment_questionnaires table (used_in_round column); if nothing is linked, the dropdown starts empty.

Include vary_by_round, rounds_of_reviews, and nested assignment_questionnaires_attributes in the assignment payload so per-round rubric choices are saved/updated.