### PR TITLE
E2605: Complete frontend support for specialized rubrics by topic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 
 # production
 /build
+/dist
 
 # misc
 .DS_Store

--- a/src/pages/Assignments/AssignmentEditor.test.tsx
+++ b/src/pages/Assignments/AssignmentEditor.test.tsx
@@ -3,7 +3,17 @@ import { render, screen, within } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { vi, beforeEach, describe, expect, it } from "vitest";
 import AssignmentEditor from "./AssignmentEditor";
-import { transformAssignmentRequest, transformAssignmentResponse, IAssignmentFormValues } from "./AssignmentUtil";
+import {
+  AUTHOR_FEEDBACK_ASSIGNMENT_QUESTIONNAIRE_ID_FIELD,
+  AUTHOR_FEEDBACK_QUESTIONNAIRE_FIELD,
+  AUTHOR_FEEDBACK_RUBRIC_ROW_KEY,
+  IAssignmentFormValues,
+  TEAMMATE_REVIEW_ASSIGNMENT_QUESTIONNAIRE_ID_FIELD,
+  TEAMMATE_REVIEW_QUESTIONNAIRE_FIELD,
+  TEAMMATE_REVIEW_RUBRIC_ROW_KEY,
+  transformAssignmentRequest,
+  transformAssignmentResponse,
+} from "./AssignmentUtil";
 
 // Mock useAPI to avoid real network calls
 const sendRequestMock = vi.fn();
@@ -123,8 +133,8 @@ describe("AssignmentEditor rubrics tab", () => {
     };
 
     expectRubricFields(getRow("Review round 2:"), "questionnaire_round_2", 2);
-    expectRubricFields(getRow("Author feedback:"), "author_feedback_questionnaire", 100);
-    expectRubricFields(getRow("Teammate review:"), "teammate_review_questionnaire", 101);
+    expectRubricFields(getRow("Author feedback:"), AUTHOR_FEEDBACK_QUESTIONNAIRE_FIELD, AUTHOR_FEEDBACK_RUBRIC_ROW_KEY);
+    expectRubricFields(getRow("Teammate review:"), TEAMMATE_REVIEW_QUESTIONNAIRE_FIELD, TEAMMATE_REVIEW_RUBRIC_ROW_KEY);
   });
 
 });
@@ -197,6 +207,50 @@ describe("transformAssignmentRequest", () => {
 
     expect(payload.assignment.assignment_questionnaires_attributes).toEqual([
       { id: 99, questionnaire_id: 201, used_in_round: 1 },
+    ]);
+  });
+
+  it("serializes special rubric questionnaire fields", () => {
+    const values: IAssignmentFormValues = {
+      id: 1,
+      name: "Test Assignment",
+      directory_path: "assignment_1",
+      spec_location: "http://example.com",
+      private: false,
+      show_template_review: false,
+      require_quiz: false,
+      has_badge: false,
+      staggered_deadline: false,
+      is_calibrated: false,
+      review_rubric_varies_by_round: true,
+      number_of_review_rounds: 2,
+      questionnaire_round_1: 101,
+      [AUTHOR_FEEDBACK_QUESTIONNAIRE_FIELD]: 301,
+      [AUTHOR_FEEDBACK_ASSIGNMENT_QUESTIONNAIRE_ID_FIELD]: 30,
+      [TEAMMATE_REVIEW_QUESTIONNAIRE_FIELD]: 401,
+      weights: [],
+      notification_limits: [],
+      use_date_updater: [],
+      submission_allowed: [],
+      review_allowed: [],
+      teammate_allowed: [],
+      metareview_allowed: [],
+      reminder: [],
+    };
+
+    const payload = JSON.parse(transformAssignmentRequest(values));
+
+    expect(payload.assignment.assignment_questionnaires_attributes).toEqual([
+      { questionnaire_id: 101, used_in_round: 1 },
+      {
+        id: 30,
+        questionnaire_id: 301,
+        used_in_round: AUTHOR_FEEDBACK_RUBRIC_ROW_KEY,
+      },
+      {
+        questionnaire_id: 401,
+        used_in_round: TEAMMATE_REVIEW_RUBRIC_ROW_KEY,
+      },
     ]);
   });
 
@@ -280,5 +334,42 @@ describe("transformAssignmentResponse", () => {
     const values = transformAssignmentResponse(JSON.stringify(assignment));
 
     expect(values.review_rubric_varies_by_topic).toBe(true);
+  });
+
+  it("prefills special rubric questionnaire fields from assignment questionnaires", () => {
+    const assignment = {
+      id: 1,
+      name: "Test Assignment",
+      directory_path: "assignment_1",
+      spec_location: "http://example.com",
+      private: false,
+      show_template_review: false,
+      require_quiz: false,
+      has_badge: false,
+      staggered_deadline: false,
+      is_calibrated: false,
+      vary_by_topic: false,
+      num_review_rounds: 1,
+      due_dates: [],
+      assignment_questionnaires: [
+        {
+          id: 30,
+          questionnaire_id: 301,
+          used_in_round: AUTHOR_FEEDBACK_RUBRIC_ROW_KEY,
+        },
+        {
+          id: 40,
+          questionnaire_id: 401,
+          used_in_round: TEAMMATE_REVIEW_RUBRIC_ROW_KEY,
+        },
+      ],
+    };
+
+    const values = transformAssignmentResponse(JSON.stringify(assignment));
+
+    expect(values[AUTHOR_FEEDBACK_QUESTIONNAIRE_FIELD]).toBe(301);
+    expect(values[AUTHOR_FEEDBACK_ASSIGNMENT_QUESTIONNAIRE_ID_FIELD]).toBe(30);
+    expect(values[TEAMMATE_REVIEW_QUESTIONNAIRE_FIELD]).toBe(401);
+    expect(values[TEAMMATE_REVIEW_ASSIGNMENT_QUESTIONNAIRE_ID_FIELD]).toBe(40);
   });
 });

--- a/src/pages/Assignments/AssignmentEditor.test.tsx
+++ b/src/pages/Assignments/AssignmentEditor.test.tsx
@@ -93,6 +93,40 @@ describe("AssignmentEditor rubrics tab", () => {
     expect(allOptions).toContain("Unlinked Rubric");
   });
 
+  it("uses distinct row keys for special rubric field names and control ids", () => {
+    render(<AssignmentEditor mode="update" />);
+
+    const getRow = (label: string) => {
+      const row = screen.getByText(label).closest("tr");
+      expect(row).not.toBeNull();
+      return row as HTMLElement;
+    };
+
+    const expectRubricFields = (
+      row: HTMLElement,
+      questionnaireName: string,
+      rowKey: number
+    ) => {
+      const questionnaire = within(row).getByRole("combobox") as HTMLSelectElement;
+      const numericInputs = within(row).getAllByRole("spinbutton") as HTMLInputElement[];
+
+      expect(questionnaire.name).toBe(questionnaireName);
+      expect(questionnaire.id).toBe(`assignment-questionnaire_${rowKey}`);
+      expect(numericInputs.map((input) => input.name)).toEqual([
+        `weights[${rowKey}]`,
+        `notification_limits[${rowKey}]`,
+      ]);
+      expect(numericInputs.map((input) => input.id)).toEqual([
+        `assignment-weight_${rowKey}`,
+        `assignment-notification_limit_${rowKey}`,
+      ]);
+    };
+
+    expectRubricFields(getRow("Review round 2:"), "questionnaire_round_2", 2);
+    expectRubricFields(getRow("Author feedback:"), "author_feedback_questionnaire", 100);
+    expectRubricFields(getRow("Teammate review:"), "teammate_review_questionnaire", 101);
+  });
+
 });
 
 describe("transformAssignmentRequest", () => {

--- a/src/pages/Assignments/AssignmentEditor.test.tsx
+++ b/src/pages/Assignments/AssignmentEditor.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, within } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { vi, beforeEach, describe, expect, it } from "vitest";
 import AssignmentEditor from "./AssignmentEditor";
-import { transformAssignmentRequest, IAssignmentFormValues } from "./AssignmentUtil";
+import { transformAssignmentRequest, transformAssignmentResponse, IAssignmentFormValues } from "./AssignmentUtil";
 
 // Mock useAPI to avoid real network calls
 const sendRequestMock = vi.fn();
@@ -193,5 +193,58 @@ describe("transformAssignmentRequest", () => {
     const payload = JSON.parse(transformAssignmentRequest(values));
 
     expect(payload.assignment.vary_by_round).toBe(false);
+  });
+
+  it("maps topic rubric variation to vary_by_topic", () => {
+    const values: IAssignmentFormValues = {
+      id: 1,
+      name: "Test Assignment",
+      directory_path: "assignment_1",
+      spec_location: "http://example.com",
+      private: false,
+      show_template_review: false,
+      require_quiz: false,
+      has_badge: false,
+      staggered_deadline: false,
+      is_calibrated: false,
+      review_rubric_varies_by_topic: true,
+      weights: [],
+      notification_limits: [],
+      use_date_updater: [],
+      submission_allowed: [],
+      review_allowed: [],
+      teammate_allowed: [],
+      metareview_allowed: [],
+      reminder: [],
+    };
+
+    const payload = JSON.parse(transformAssignmentRequest(values));
+
+    expect(payload.assignment.vary_by_topic).toBe(true);
+  });
+});
+
+describe("transformAssignmentResponse", () => {
+  it("prefills topic rubric variation from vary_by_topic", () => {
+    const assignment = {
+      id: 1,
+      name: "Test Assignment",
+      directory_path: "assignment_1",
+      spec_location: "http://example.com",
+      private: false,
+      show_template_review: false,
+      require_quiz: false,
+      has_badge: false,
+      staggered_deadline: false,
+      is_calibrated: false,
+      vary_by_topic: true,
+      num_review_rounds: 1,
+      due_dates: [],
+      assignment_questionnaires: [],
+    };
+
+    const values = transformAssignmentResponse(JSON.stringify(assignment));
+
+    expect(values.review_rubric_varies_by_topic).toBe(true);
   });
 });

--- a/src/pages/Assignments/AssignmentEditor.tsx
+++ b/src/pages/Assignments/AssignmentEditor.tsx
@@ -2,7 +2,13 @@ import * as Yup from "yup";
 
 import { Button, Modal } from "react-bootstrap";
 import { Form, Formik, FormikHelpers } from "formik";
-import { IAssignmentFormValues, transformAssignmentRequest } from "./AssignmentUtil";
+import {
+  AUTHOR_FEEDBACK_RUBRIC_ROW_KEY,
+  IAssignmentFormValues,
+  TEAMMATE_REVIEW_RUBRIC_ROW_KEY,
+  getSpecialRubricQuestionnaireField,
+  transformAssignmentRequest,
+} from "./AssignmentUtil";
 import { IEditor } from "../../utils/interfaces";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -63,9 +69,6 @@ interface TopicRubricMapping {
 
 const getTopicRubricMappingKey = (topicDatabaseId: number, usedInRound: number | null) =>
   `${topicDatabaseId}-${usedInRound ?? "default"}`;
-
-const AUTHOR_FEEDBACK_RUBRIC_ROW_KEY = 100;
-const TEAMMATE_REVIEW_RUBRIC_ROW_KEY = 101;
 
 const initialValues: IAssignmentFormValues = {
   name: "",
@@ -767,8 +770,19 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
   if (mode === "update") {
     // Prefill per-round questionnaire selections and ids
     (assignmentData.assignment_questionnaires || []).forEach((aq: any) => {
-      if (aq.used_in_round && aq.questionnaire) {
-        formInitialValues[`questionnaire_round_${aq.used_in_round}`] = aq.questionnaire.id;
+      const questionnaireId = aq.questionnaire_id ?? aq.questionnaire?.id;
+      if (!questionnaireId) return;
+
+      const specialRubricField = getSpecialRubricQuestionnaireField(
+        aq.used_in_round,
+        aq.questionnaire?.questionnaire_type ?? aq.questionnaire_type
+      );
+
+      if (specialRubricField) {
+        formInitialValues[specialRubricField.questionnaireField] = questionnaireId;
+        formInitialValues[specialRubricField.assignmentQuestionnaireIdField] = aq.id;
+      } else if (aq.used_in_round) {
+        formInitialValues[`questionnaire_round_${aq.used_in_round}`] = questionnaireId;
         formInitialValues[`assignment_questionnaire_id_${aq.used_in_round}`] = aq.id;
       }
     });
@@ -1001,7 +1015,7 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
                             controlId={questionnaireControlId}
                             name={questionnaireFieldName}
                             options={row.original.questionnaire_options || []}
-                          // Formik initialValues handles prefill via questionnaire_round_X fields
+                          // Formik initialValues handles prefill for review and special rubric fields.
                           />
                             );
                           })()}

--- a/src/pages/Assignments/AssignmentEditor.tsx
+++ b/src/pages/Assignments/AssignmentEditor.tsx
@@ -4,7 +4,7 @@ import { Button, Modal } from "react-bootstrap";
 import { Form, Formik, FormikHelpers } from "formik";
 import { IAssignmentFormValues, transformAssignmentRequest } from "./AssignmentUtil";
 import { IEditor } from "../../utils/interfaces";
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import { useLoaderData, useLocation, useNavigate, useParams } from "react-router-dom";
 import FormInput from "../../components/Form/FormInput";
@@ -60,6 +60,9 @@ interface TopicRubricMapping {
   project_topic_id: number | null;
   used_in_round: number | null;
 }
+
+const getTopicRubricMappingKey = (topicDatabaseId: number, usedInRound: number | null) =>
+  `${topicDatabaseId}-${usedInRound ?? "default"}`;
 
 const initialValues: IAssignmentFormValues = {
   name: "",
@@ -176,6 +179,8 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
   const [selectedDutyIds, setSelectedDutyIds] = useState<number[]>([]);
   const [roleBasedLocalError, setRoleBasedLocalError] = useState<string | null>(null);
   const [topicRubricMappings, setTopicRubricMappings] = useState<TopicRubricMapping[]>([]);
+  const [pendingTopicRubricMappingKeys, setPendingTopicRubricMappingKeys] = useState<Set<string>>(new Set());
+  const pendingTopicRubricMappingKeysRef = useRef<Set<string>>(new Set());
 
 
    useEffect(() => {
@@ -303,8 +308,8 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
     }, [id, fetchTopics]);
 
   const refreshTopicRubricMappings = useCallback(() => {
-    if (!id) return;
-    fetchTopicRubricMappings({ url: `/assignment_questionnaires?assignment_id=${id}` });
+    if (!id) return Promise.resolve();
+    return fetchTopicRubricMappings({ url: `/assignment_questionnaires?assignment_id=${id}` });
   }, [fetchTopicRubricMappings, id]);
 
   useEffect(() => {
@@ -535,6 +540,21 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
           );
         }, [topicRubricMappings]);
 
+        const updateTopicRubricMappingPending = useCallback((key: string, isPending: boolean) => {
+          const nextKeys = new Set(pendingTopicRubricMappingKeysRef.current);
+          if (isPending) {
+            nextKeys.add(key);
+          } else {
+            nextKeys.delete(key);
+          }
+          pendingTopicRubricMappingKeysRef.current = nextKeys;
+          setPendingTopicRubricMappingKeys(nextKeys);
+        }, []);
+
+        const isTopicRubricMappingPending = useCallback((topicDatabaseId: number, usedInRound: number | null) => {
+          return pendingTopicRubricMappingKeys.has(getTopicRubricMappingKey(topicDatabaseId, usedInRound));
+        }, [pendingTopicRubricMappingKeys]);
+
         const handleTopicRubricChange = useCallback(async (
           topicDatabaseId: number,
           questionnaireId: number | null,
@@ -542,6 +562,10 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
         ) => {
           if (!id) return;
 
+          const mappingKey = getTopicRubricMappingKey(topicDatabaseId, usedInRound);
+          if (pendingTopicRubricMappingKeysRef.current.has(mappingKey)) return;
+
+          updateTopicRubricMappingPending(mappingKey, true);
           const existingMapping = findTopicRubricMapping(topicDatabaseId, usedInRound);
 
           try {
@@ -577,12 +601,14 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
               });
             }
 
-            refreshTopicRubricMappings();
+            await refreshTopicRubricMappings();
             dispatch(alertActions.showAlert({ variant: "success", message: "Topic rubric mapping saved successfully" }));
           } catch {
             // useAPI surfaces the request error through saveTopicRubricError.
+          } finally {
+            updateTopicRubricMappingPending(mappingKey, false);
           }
-        }, [dispatch, findTopicRubricMapping, id, refreshTopicRubricMappings, saveTopicRubricMapping]);
+        }, [dispatch, findTopicRubricMapping, id, refreshTopicRubricMappings, saveTopicRubricMapping, updateTopicRubricMappingPending]);
       
 
 
@@ -861,6 +887,7 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
             onEditTopic={handleEditTopic}
             onCreateTopic={handleCreateTopic}
             onApplyPartnerAd={handleApplyPartnerAd}
+            isTopicRubricMappingPending={isTopicRubricMappingPending}
             onTopicRubricChange={handleTopicRubricChange}
             onTopicsChanged={() => id && fetchTopics({ url: `/project_topics?assignment_id=${id}` })}
                 />

--- a/src/pages/Assignments/AssignmentEditor.tsx
+++ b/src/pages/Assignments/AssignmentEditor.tsx
@@ -676,10 +676,16 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
       return;
     }
 
-    // validate sum of weights = 100%
-    const totalWeight = values.weights?.reduce((acc: number, curr: number) => acc + curr, 0) || 0;
+    // validate sum of weights = 100% only when the user has actually entered weights
+    const filledWeights = (values.weights || []).filter(
+      (weight: any) => weight !== "" && weight !== null && weight !== undefined
+    );
+    const totalWeight = filledWeights.reduce(
+      (acc: number, curr: any) => acc + Number(curr),
+      0
+    );
 
-    const hasWeights = (values.weights?.length ?? 0) > 0;
+    const hasWeights = filledWeights.length > 0;
 
     if (hasWeights && totalWeight !== 100) {
       dispatch(alertActions.showAlert({ variant: "danger", message: "Sum of weights must be 100%" }));
@@ -950,12 +956,27 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
                       },
                       {
                         cell: ({ row }) => <div style={{ marginRight: '10px' }}>{row.original.questionnaire_type === 'dropdown' &&
+                          (() => {
+                            let questionnaireFieldName = `questionnaire_round_${row.original.id}`;
+                            let questionnaireControlId = `assignment-questionnaire_${row.original.id}`;
+
+                            if (row.original.title === "Author feedback:") {
+                              questionnaireFieldName = "author_feedback_questionnaire";
+                              questionnaireControlId = "assignment-author_feedback_questionnaire";
+                            } else if (row.original.title === "Teammate review:") {
+                              questionnaireFieldName = "teammate_review_questionnaire";
+                              questionnaireControlId = "assignment-teammate_review_questionnaire";
+                            }
+
+                            return (
                           <FormSelect
-                            controlId={`assignment-questionnaire_${row.original.id}`}
-                            name={`questionnaire_round_${row.original.id}`}
+                            controlId={questionnaireControlId}
+                            name={questionnaireFieldName}
                             options={row.original.questionnaire_options || []}
                           // Formik initialValues handles prefill via questionnaire_round_X fields
-                          />}
+                          />
+                            );
+                          })()}
                           {row.original.questionnaire_type === 'tag_prompts' &&
                             <div style={{ marginBottom: '10px' }}><Button variant="outline-secondary">+Tag prompt+</Button>
                               <Button variant="outline-secondary">-Tag prompt-</Button></div>}</div>,
@@ -1374,7 +1395,7 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
 
             {/* Submit button */}
               <div className="mt-3 d-flex justify-content-start gap-2" style={{ alignItems: 'center' }}>
-                <Button type="submit" variant="outline-secondary">
+                <Button type="button" variant="outline-secondary" onClick={() => formik.submitForm()}>
                   Save
                 </Button> |
                 <a href="/assignments" style={{ color: '#a4a366', textDecoration: 'none' }}>Back</a>

--- a/src/pages/Assignments/AssignmentEditor.tsx
+++ b/src/pages/Assignments/AssignmentEditor.tsx
@@ -64,6 +64,9 @@ interface TopicRubricMapping {
 const getTopicRubricMappingKey = (topicDatabaseId: number, usedInRound: number | null) =>
   `${topicDatabaseId}-${usedInRound ?? "default"}`;
 
+const AUTHOR_FEEDBACK_RUBRIC_ROW_KEY = 100;
+const TEAMMATE_REVIEW_RUBRIC_ROW_KEY = 101;
+
 const initialValues: IAssignmentFormValues = {
   name: "",
   directory_path: "",
@@ -921,6 +924,7 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
                           return Array.from({ length: rounds }, (_, i) => ([
                             {
                               id: i + 1,
+                              rowKey: i + 1,
                               title: `Review round ${i + 1}:`,
                               questionnaire_options: questionnaireOptions,
                               selected_questionnaire: roundSelections[i + 1]?.id,
@@ -936,6 +940,7 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
                         return [
                           {
                             id: 0,
+                            rowKey: 0,
                             title: "Review rubric:",
                             questionnaire_options: questionnaireOptions,
                             selected_questionnaire: roundSelections[1]?.id,
@@ -950,6 +955,7 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
                       })(),
                       {
                         id: formik.values.number_of_review_rounds ?? 0,
+                        rowKey: AUTHOR_FEEDBACK_RUBRIC_ROW_KEY,
                         title: "Author feedback:",
                         questionnaire_options: [{ label: 'Standard author feedback', value: 'Standard author feedback' }],
                         questionnaire_type: 'dropdown',
@@ -961,6 +967,7 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
                       },
                       {
                         id: (formik.values.number_of_review_rounds ?? 0) + 1,
+                        rowKey: TEAMMATE_REVIEW_RUBRIC_ROW_KEY,
                         title: "Teammate review:",
                         questionnaire_options: [{ label: 'Review with Github metrics', value: 'Review with Github metrics' }],
                         questionnaire_type: 'dropdown',
@@ -979,15 +986,14 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
                       {
                         cell: ({ row }) => <div style={{ marginRight: '10px' }}>{row.original.questionnaire_type === 'dropdown' &&
                           (() => {
+                            const rubricRowKey = row.original.rowKey ?? row.original.id;
                             let questionnaireFieldName = `questionnaire_round_${row.original.id}`;
-                            let questionnaireControlId = `assignment-questionnaire_${row.original.id}`;
+                            let questionnaireControlId = `assignment-questionnaire_${rubricRowKey}`;
 
                             if (row.original.title === "Author feedback:") {
                               questionnaireFieldName = "author_feedback_questionnaire";
-                              questionnaireControlId = "assignment-author_feedback_questionnaire";
                             } else if (row.original.title === "Teammate review:") {
                               questionnaireFieldName = "teammate_review_questionnaire";
-                              questionnaireControlId = "assignment-teammate_review_questionnaire";
                             }
 
                             return (
@@ -1010,24 +1016,14 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
                             return <div style={{ marginRight: '10px' }} />;
                           }
 
-                          // Use distinct indices in the weights array so that
-                          // different rows (review rubric, author feedback,
-                          // teammate review, etc.) do not overwrite each other.
-                          let weightIndex: number;
-                          if (row.original.title === "Author feedback:") {
-                            weightIndex = 100; // separate slot for author feedback
-                          } else if (row.original.title === "Teammate review:") {
-                            weightIndex = 101; // separate slot for teammate review
-                          } else {
-                            weightIndex = row.original.id;
-                          }
+                          const rubricRowKey = row.original.rowKey ?? row.original.id;
 
                           return (
                             <div style={{ marginRight: '10px' }}>
                               <div style={{ width: '70px', display: 'flex', alignItems: 'center' }}>
                                 <FormInput
-                                  controlId={`assignment-weight_${row.original.id}`}
-                                  name={`weights[${weightIndex}]`}
+                                  controlId={`assignment-weight_${rubricRowKey}`}
+                                  name={`weights[${rubricRowKey}]`}
                                   type="number"
                                 />
                                 %
@@ -1038,8 +1034,24 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
                         accessorKey: `weights`, header: "Weight", enableSorting: false, enableColumnFilter: false
                       },
                       {
-                        cell: ({ row }) => <>{row.original.questionnaire_type === 'dropdown' &&
-                          <><div style={{ width: '70px', display: 'flex', alignItems: 'center' }}><FormInput controlId={`assignment-notification_limit_${row.original.id}`} name={`notification_limits[${row.original.id}]`} type="number" />%</div></>}</>,
+                        cell: ({ row }) => {
+                          if (row.original.questionnaire_type !== 'dropdown') {
+                            return null;
+                          }
+
+                          const rubricRowKey = row.original.rowKey ?? row.original.id;
+
+                          return (
+                            <div style={{ width: '70px', display: 'flex', alignItems: 'center' }}>
+                              <FormInput
+                                controlId={`assignment-notification_limit_${rubricRowKey}`}
+                                name={`notification_limits[${rubricRowKey}]`}
+                                type="number"
+                              />
+                              %
+                            </div>
+                          );
+                        },
                         accessorKey: "notification_limits", header: "Notification Limit", enableSorting: false, enableColumnFilter: false
                       },
                     ]}

--- a/src/pages/Assignments/AssignmentEditor.tsx
+++ b/src/pages/Assignments/AssignmentEditor.tsx
@@ -53,6 +53,14 @@ interface TopicData {
   updatedAt?: string;
 }
 
+interface TopicRubricMapping {
+  id: number;
+  questionnaire_id: number;
+  questionnaire_name?: string;
+  project_topic_id: number | null;
+  used_in_round: number | null;
+}
+
 const initialValues: IAssignmentFormValues = {
   name: "",
   directory_path: "",
@@ -115,6 +123,8 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
   const [calibrationSubmissions, setCalibrationSubmissions] = useState<any[]>([]);
 
   const { data: topicsResponse, error: topicsApiError, sendRequest: fetchTopics } = useAPI();
+  const { data: topicRubricMappingsResponse, error: topicRubricMappingsError, sendRequest: fetchTopicRubricMappings } = useAPI();
+  const { error: saveTopicRubricError, sendRequest: saveTopicRubricMapping } = useAPI();
   const { data: updateResponse, error: updateError, sendRequest: updateAssignment } = useAPI();
   const { data: deleteResponse, error: deleteError, sendRequest: deleteTopic } = useAPI();
   const { data: createResponse, error: createError, sendRequest: createTopic } = useAPI();
@@ -165,6 +175,7 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
   const [assignmentDuties, setAssignmentDuties] = useState<any[]>([]);
   const [selectedDutyIds, setSelectedDutyIds] = useState<number[]>([]);
   const [roleBasedLocalError, setRoleBasedLocalError] = useState<string | null>(null);
+  const [topicRubricMappings, setTopicRubricMappings] = useState<TopicRubricMapping[]>([]);
 
 
    useEffect(() => {
@@ -291,6 +302,15 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
       }
     }, [id, fetchTopics]);
 
+  const refreshTopicRubricMappings = useCallback(() => {
+    if (!id) return;
+    fetchTopicRubricMappings({ url: `/assignment_questionnaires?assignment_id=${id}` });
+  }, [fetchTopicRubricMappings, id]);
+
+  useEffect(() => {
+    refreshTopicRubricMappings();
+  }, [refreshTopicRubricMappings]);
+
   const refreshAccessibleDuties = useCallback(() => {
     fetchAccessibleDuties({ url: `/duties/accessible_duties` });
   }, [fetchAccessibleDuties]);
@@ -343,6 +363,14 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
           setTopicsLoading(false);
         }
       }, [topicsResponse]);
+
+  useEffect(() => {
+    if (topicRubricMappingsResponse?.data) {
+      const mappings = (topicRubricMappingsResponse.data || [])
+        .filter((mapping: any) => mapping.project_topic_id !== null && mapping.project_topic_id !== undefined);
+      setTopicRubricMappings(mappings);
+    }
+  }, [topicRubricMappingsResponse]);
     
       // Handle topics API errors
   useEffect(() => {
@@ -351,6 +379,18 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
       setTopicsLoading(false);
     }
   }, [topicsApiError]);
+
+  useEffect(() => {
+    if (topicRubricMappingsError) {
+      dispatch(alertActions.showAlert({ variant: "danger", message: topicRubricMappingsError }));
+    }
+  }, [topicRubricMappingsError, dispatch]);
+
+  useEffect(() => {
+    if (saveTopicRubricError) {
+      dispatch(alertActions.showAlert({ variant: "danger", message: saveTopicRubricError }));
+    }
+  }, [saveTopicRubricError, dispatch]);
 
   const toggleDutySelection = useCallback((dutyId: number) => {
     setSelectedDutyIds((prev) =>
@@ -491,6 +531,62 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
           console.log(`Applying to partner ad for topic ${topicId}: ${applicationText}`);
           // TODO: Implement partner ad application logic
         }, []);
+
+        const findTopicRubricMapping = useCallback((topicDatabaseId: number, usedInRound: number | null) => {
+          return topicRubricMappings.find((mapping) =>
+            Number(mapping.project_topic_id) === Number(topicDatabaseId) &&
+            (mapping.used_in_round ?? null) === (usedInRound ?? null)
+          );
+        }, [topicRubricMappings]);
+
+        const handleTopicRubricChange = useCallback(async (
+          topicDatabaseId: number,
+          questionnaireId: number | null,
+          usedInRound: number | null
+        ) => {
+          if (!id) return;
+
+          const existingMapping = findTopicRubricMapping(topicDatabaseId, usedInRound);
+
+          try {
+            if (!questionnaireId) {
+              if (existingMapping) {
+                await saveTopicRubricMapping({
+                  url: `/assignment_questionnaires/${existingMapping.id}`,
+                  method: HttpMethod.DELETE,
+                });
+              }
+            } else if (existingMapping) {
+              await saveTopicRubricMapping({
+                url: `/assignment_questionnaires/${existingMapping.id}`,
+                method: HttpMethod.PATCH,
+                data: {
+                  assignment_questionnaire: {
+                    questionnaire_id: questionnaireId,
+                  },
+                },
+              });
+            } else {
+              await saveTopicRubricMapping({
+                url: `/assignment_questionnaires`,
+                method: HttpMethod.POST,
+                data: {
+                  assignment_questionnaire: {
+                    assignment_id: Number(id),
+                    questionnaire_id: questionnaireId,
+                    project_topic_id: topicDatabaseId,
+                    used_in_round: usedInRound,
+                  },
+                },
+              });
+            }
+
+            refreshTopicRubricMappings();
+            dispatch(alertActions.showAlert({ variant: "success", message: "Topic rubric mapping saved successfully" }));
+          } catch {
+            // useAPI surfaces the request error through saveTopicRubricError.
+          }
+        }, [dispatch, findTopicRubricMapping, id, refreshTopicRubricMappings, saveTopicRubricMapping]);
       
 
 
@@ -624,6 +720,13 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
     value: q.id,
   }));
 
+  const reviewRubricOptions = (assignmentData.questionnaires || [])
+    .filter((q: any) => q.questionnaire_type === "ReviewQuestionnaire")
+    .map((q: any) => ({
+      label: q.name,
+      value: q.id,
+    }));
+
   const reviewRounds = assignmentData.number_of_review_rounds;
 
   // Build initial form values from existing assignment data (update) or defaults (create)
@@ -746,12 +849,18 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
             topicsData={topicsData}
             topicsLoading={topicsLoading}
             topicsError={topicsError}
+            varyByTopic={!!formik.values.review_rubric_varies_by_topic}
+            varyByRound={!!formik.values.review_rubric_varies_by_round}
+            reviewRounds={formik.values.number_of_review_rounds || reviewRounds || 1}
+            reviewRubricOptions={reviewRubricOptions}
+            topicRubricMappings={topicRubricMappings}
             onTopicSettingChange={handleTopicSettingChange}
             onDropTeam={handleDropTeam}
             onDeleteTopic={handleDeleteTopic}
             onEditTopic={handleEditTopic}
             onCreateTopic={handleCreateTopic}
             onApplyPartnerAd={handleApplyPartnerAd}
+            onTopicRubricChange={handleTopicRubricChange}
             onTopicsChanged={() => id && fetchTopics({ url: `/project_topics?assignment_id=${id}` })}
                 />
               </Tab>

--- a/src/pages/Assignments/AssignmentEditor.tsx
+++ b/src/pages/Assignments/AssignmentEditor.tsx
@@ -473,7 +473,6 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
         }, [dropTeamRequest]);
       
         const handleDeleteTopic = useCallback((topicIdentifier: string) => {
-          console.log(`Delete topic ${topicIdentifier}`);
           if (id) {
             deleteTopic({
               url: `/project_topics`,
@@ -487,7 +486,6 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
         }, [id, deleteTopic]);
       
         const handleEditTopic = useCallback((dbId: string, updatedData: any) => {
-          console.log(`Edit topic DB id ${dbId}`, updatedData);
           updateTopic({
             url: `/project_topics/${dbId}`,
             method: 'PATCH',
@@ -506,7 +504,6 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
         }, [id, updateTopic]);
       
         const handleCreateTopic = useCallback((topicData: any) => {
-          console.log(`Create topic`, topicData);
           if (id) {
             createTopic({
               url: `/project_topics`,
@@ -528,7 +525,6 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
         }, [id, createTopic]);
       
         const handleApplyPartnerAd = useCallback((topicId: string, applicationText: string) => {
-          console.log(`Applying to partner ad for topic ${topicId}: ${applicationText}`);
           // TODO: Implement partner ad application logic
         }, []);
 
@@ -700,7 +696,6 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
     }
     // to be used to display message when assignment is created
     assignmentData.name = values.name;
-    console.log(values);
     sendRequest({
       url: url,
       method: method,

--- a/src/pages/Assignments/AssignmentUtil.ts
+++ b/src/pages/Assignments/AssignmentUtil.ts
@@ -177,6 +177,7 @@ export const transformAssignmentRequest = (values: IAssignmentFormValues) => {
 
     // Per-round rubric configuration
     vary_by_round: values.review_rubric_varies_by_round,
+    vary_by_topic: values.review_rubric_varies_by_topic,
     rounds_of_reviews: values.number_of_review_rounds,
     assignment_questionnaires_attributes: assignmentQuestionnaires,
 
@@ -240,6 +241,7 @@ export const transformAssignmentResponse = (assignmentResponse: string) => {
     // review rounds / rubrics
     review_rubric_varies_by_round:
       assignment.varying_rubrics_by_round ?? assignment.vary_by_round,
+    review_rubric_varies_by_topic: (assignment as any).vary_by_topic ?? false,
     number_of_review_rounds: assignment.num_review_rounds,
     is_role_based: (assignment as any).is_role_based ?? false,
 

--- a/src/pages/Assignments/AssignmentUtil.ts
+++ b/src/pages/Assignments/AssignmentUtil.ts
@@ -79,27 +79,88 @@ export interface IAssignmentFormValues {
     used_in_round?: number;
     project_topic_id?: number | null;
     questionnaire_id?: number;
-    questionnaire?: { id: number; name: string };
+    questionnaire?: { id: number; name: string; questionnaire_type?: string };
   }[];
   [key: string]: any;
 }
 
+export const AUTHOR_FEEDBACK_RUBRIC_ROW_KEY = 100;
+export const TEAMMATE_REVIEW_RUBRIC_ROW_KEY = 101;
+export const AUTHOR_FEEDBACK_QUESTIONNAIRE_FIELD = "author_feedback_questionnaire";
+export const TEAMMATE_REVIEW_QUESTIONNAIRE_FIELD = "teammate_review_questionnaire";
+export const AUTHOR_FEEDBACK_ASSIGNMENT_QUESTIONNAIRE_ID_FIELD = "author_feedback_assignment_questionnaire_id";
+export const TEAMMATE_REVIEW_ASSIGNMENT_QUESTIONNAIRE_ID_FIELD = "teammate_review_assignment_questionnaire_id";
+
+export const getSpecialRubricQuestionnaireField = (
+  usedInRound?: number | null,
+  questionnaireType?: string | null
+) => {
+  const normalizedUsedInRound =
+    usedInRound === null || usedInRound === undefined ? null : Number(usedInRound);
+  const normalizedQuestionnaireType = questionnaireType?.replace(/\s+/g, "").toLowerCase();
+
+  if (
+    normalizedUsedInRound === AUTHOR_FEEDBACK_RUBRIC_ROW_KEY ||
+    normalizedQuestionnaireType?.includes("authorfeedback")
+  ) {
+    return {
+      rowKey: AUTHOR_FEEDBACK_RUBRIC_ROW_KEY,
+      questionnaireField: AUTHOR_FEEDBACK_QUESTIONNAIRE_FIELD,
+      assignmentQuestionnaireIdField: AUTHOR_FEEDBACK_ASSIGNMENT_QUESTIONNAIRE_ID_FIELD,
+    };
+  }
+
+  if (
+    normalizedUsedInRound === TEAMMATE_REVIEW_RUBRIC_ROW_KEY ||
+    normalizedQuestionnaireType?.includes("teammatereview")
+  ) {
+    return {
+      rowKey: TEAMMATE_REVIEW_RUBRIC_ROW_KEY,
+      questionnaireField: TEAMMATE_REVIEW_QUESTIONNAIRE_FIELD,
+      assignmentQuestionnaireIdField: TEAMMATE_REVIEW_ASSIGNMENT_QUESTIONNAIRE_ID_FIELD,
+    };
+  }
+
+  return null;
+};
 
 export const transformAssignmentRequest = (values: IAssignmentFormValues) => {
   // Build nested attributes for assignment_questionnaires from the per-round form fields to create or update corresponding rows
   const assignmentQuestionnaires: { id?: number; questionnaire_id: number; used_in_round: number }[] = [];
+  const addAssignmentQuestionnaire = (
+    questionnaireField: string,
+    assignmentQuestionnaireIdField: string,
+    usedInRound: number
+  ) => {
+    const questionnaireId = values[questionnaireField];
+    if (!questionnaireId) return;
+
+    assignmentQuestionnaires.push({
+      id: values[assignmentQuestionnaireIdField],
+      questionnaire_id: questionnaireId,
+      used_in_round: usedInRound,
+    });
+  };
+
   const roundCount = values.number_of_review_rounds ?? 0;
   for (let i = 1; i <= roundCount; i += 1) {
-    const questionnaireId = values[`questionnaire_round_${i}`];
-    if (questionnaireId) {
-      const existingId = values[`assignment_questionnaire_id_${i}`];
-      assignmentQuestionnaires.push({
-        id: existingId,
-        questionnaire_id: questionnaireId,
-        used_in_round: i,
-      });
-    }
+    addAssignmentQuestionnaire(
+      `questionnaire_round_${i}`,
+      `assignment_questionnaire_id_${i}`,
+      i
+    );
   }
+
+  addAssignmentQuestionnaire(
+    AUTHOR_FEEDBACK_QUESTIONNAIRE_FIELD,
+    AUTHOR_FEEDBACK_ASSIGNMENT_QUESTIONNAIRE_ID_FIELD,
+    AUTHOR_FEEDBACK_RUBRIC_ROW_KEY
+  );
+  addAssignmentQuestionnaire(
+    TEAMMATE_REVIEW_QUESTIONNAIRE_FIELD,
+    TEAMMATE_REVIEW_ASSIGNMENT_QUESTIONNAIRE_ID_FIELD,
+    TEAMMATE_REVIEW_RUBRIC_ROW_KEY
+  );
 
   const assignment: IAssignmentRequest = {
     // Core fields
@@ -254,6 +315,30 @@ export const transformAssignmentResponse = (assignmentResponse: string) => {
     due_dates: assignment.due_dates,
     assignment_questionnaires: assignment.assignment_questionnaires,
   };
+
+  (assignment.assignment_questionnaires || []).forEach((assignmentQuestionnaire: any) => {
+    const questionnaireId =
+      assignmentQuestionnaire.questionnaire_id ?? assignmentQuestionnaire.questionnaire?.id;
+    if (!questionnaireId) return;
+
+    const specialRubricField = getSpecialRubricQuestionnaireField(
+      assignmentQuestionnaire.used_in_round,
+      assignmentQuestionnaire.questionnaire?.questionnaire_type ?? assignmentQuestionnaire.questionnaire_type
+    );
+
+    if (specialRubricField) {
+      assignmentValues[specialRubricField.questionnaireField] = questionnaireId;
+      assignmentValues[specialRubricField.assignmentQuestionnaireIdField] = assignmentQuestionnaire.id;
+      return;
+    }
+
+    if (assignmentQuestionnaire.used_in_round) {
+      assignmentValues[`questionnaire_round_${assignmentQuestionnaire.used_in_round}`] = questionnaireId;
+      assignmentValues[`assignment_questionnaire_id_${assignmentQuestionnaire.used_in_round}`] =
+        assignmentQuestionnaire.id;
+    }
+  });
+
   return assignmentValues;
 };
 

--- a/src/pages/Assignments/AssignmentUtil.ts
+++ b/src/pages/Assignments/AssignmentUtil.ts
@@ -77,6 +77,8 @@ export interface IAssignmentFormValues {
   assignment_questionnaires?: {
     id: number;
     used_in_round?: number;
+    project_topic_id?: number | null;
+    questionnaire_id?: number;
     questionnaire?: { id: number; name: string };
   }[];
   [key: string]: any;

--- a/src/pages/Assignments/tabs/TopicsTab.test.tsx
+++ b/src/pages/Assignments/tabs/TopicsTab.test.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { describe, expect, it, vi } from "vitest";
+import TopicsTab from "./TopicsTab";
+
+const baseProps = {
+  assignmentName: "Program 4",
+  assignmentId: "1",
+  topicSettings: {
+    allowTopicSuggestions: false,
+    enableBidding: false,
+    enableAuthorsReview: true,
+    allowReviewerChoice: true,
+    allowBookmarks: false,
+    allowBiddingForReviewers: false,
+    allowAdvertiseForPartners: false,
+  },
+  topicsData: [
+    {
+      id: "T1",
+      databaseId: 10,
+      name: "Security Topic",
+      assignedTeams: [],
+      waitlistedTeams: [],
+      questionnaire: "Default rubric",
+      numSlots: 2,
+      availableSlots: 2,
+      bookmarks: [],
+    },
+  ],
+  onTopicSettingChange: vi.fn(),
+  onDropTeam: vi.fn(),
+  onDeleteTopic: vi.fn(),
+  onEditTopic: vi.fn(),
+  onCreateTopic: vi.fn(),
+  onApplyPartnerAd: vi.fn(),
+};
+
+describe("TopicsTab topic rubric selectors", () => {
+  it("shows a review rubric dropdown for each topic when topic variation is enabled", () => {
+    render(
+      <TopicsTab
+        {...baseProps}
+        varyByTopic
+        reviewRubricOptions={[{ label: "Security Rubric", value: 7 }]}
+        topicRubricMappings={[
+          {
+            id: 99,
+            questionnaire_id: 7,
+            questionnaire_name: "Security Rubric",
+            project_topic_id: 10,
+            used_in_round: null,
+          },
+        ]}
+      />
+    );
+
+    const row = screen.getByText("Security Topic").closest("tr");
+    expect(row).not.toBeNull();
+    const rubricSelect = within(row as HTMLElement).getByLabelText("Rubric for Security Topic") as HTMLSelectElement;
+
+    expect(rubricSelect.value).toBe("7");
+    expect(within(rubricSelect).getByText("Use assignment default rubric")).toBeInTheDocument();
+    expect(within(rubricSelect).getByText("Security Rubric")).toBeInTheDocument();
+  });
+
+  it("sends topic, questionnaire, and round when a topic rubric changes", () => {
+    const onTopicRubricChange = vi.fn();
+
+    render(
+      <TopicsTab
+        {...baseProps}
+        varyByTopic
+        varyByRound
+        reviewRounds={2}
+        reviewRubricOptions={[{ label: "Round Rubric", value: 8 }]}
+        onTopicRubricChange={onTopicRubricChange}
+      />
+    );
+
+    const roundTwoSelect = screen.getByLabelText("Round 2 for Security Topic");
+    fireEvent.change(roundTwoSelect, { target: { value: "8" } });
+
+    expect(onTopicRubricChange).toHaveBeenCalledWith(10, 8, 2);
+  });
+});

--- a/src/pages/Assignments/tabs/TopicsTab.test.tsx
+++ b/src/pages/Assignments/tabs/TopicsTab.test.tsx
@@ -84,4 +84,20 @@ describe("TopicsTab topic rubric selectors", () => {
 
     expect(onTopicRubricChange).toHaveBeenCalledWith(10, 8, 2);
   });
+
+  it("disables only the topic rubric selector currently being saved", () => {
+    render(
+      <TopicsTab
+        {...baseProps}
+        varyByTopic
+        varyByRound
+        reviewRounds={2}
+        reviewRubricOptions={[{ label: "Round Rubric", value: 8 }]}
+        isTopicRubricMappingPending={(_topicDatabaseId, usedInRound) => usedInRound === 2}
+      />
+    );
+
+    expect(screen.getByLabelText("Round 1 for Security Topic")).not.toBeDisabled();
+    expect(screen.getByLabelText("Round 2 for Security Topic")).toBeDisabled();
+  });
 });

--- a/src/pages/Assignments/tabs/TopicsTab.tsx
+++ b/src/pages/Assignments/tabs/TopicsTab.tsx
@@ -390,7 +390,7 @@ const TopicsTab = ({
         <h4>Topics for {assignmentName} assignment</h4>
 
         {/* Topic Settings */}
-        <Form className="topics-settings-form">
+        <div className="topics-settings-form">
               <Form.Check
                 type="checkbox"
                 id="allowTopicSuggestions"
@@ -446,7 +446,7 @@ const TopicsTab = ({
                 checked={topicSettings.allowBiddingForReviewers}
                 onChange={(e) => onTopicSettingChange('allowBiddingForReviewers', e.target.checked)}
               />
-        </Form>
+        </div>
 
         {/* Error Message */}
         {topicsError && (

--- a/src/pages/Assignments/tabs/TopicsTab.tsx
+++ b/src/pages/Assignments/tabs/TopicsTab.tsx
@@ -100,6 +100,7 @@ interface TopicsTabProps {
   onCreateTopic?: (topicData: any) => void;
   // Handler for partner ad application submission
   onApplyPartnerAd: (topicId: string, applicationText: string) => void;
+  isTopicRubricMappingPending?: (topicDatabaseId: number, usedInRound: number | null) => boolean;
   onTopicRubricChange?: (topicDatabaseId: number, questionnaireId: number | null, usedInRound: number | null) => void;
   onTopicsChanged?: () => void;
 }
@@ -124,6 +125,7 @@ const TopicsTab = ({
   onEditTopic,
   onCreateTopic,
   onApplyPartnerAd,
+  isTopicRubricMappingPending,
   onTopicRubricChange,
   onTopicsChanged,
 }: TopicsTabProps) => {
@@ -352,6 +354,7 @@ const TopicsTab = ({
   const renderRubricSelector = (topic: TopicData, usedInRound: number | null) => {
     const mapping = findTopicRubricMapping(topic.databaseId, usedInRound);
     const label = usedInRound ? `Round ${usedInRound}` : "Rubric";
+    const isSaving = isTopicRubricMappingPending?.(topic.databaseId, usedInRound) ?? false;
 
     return (
       <div key={`${topic.databaseId}-${usedInRound ?? "default"}`} className="mb-2">
@@ -359,7 +362,8 @@ const TopicsTab = ({
         <Form.Select
           size="sm"
           value={mapping?.questionnaire_id ?? ""}
-          disabled={reviewRubricOptions.length === 0}
+          disabled={reviewRubricOptions.length === 0 || isSaving}
+          aria-busy={isSaving}
           aria-label={`${label} for ${topic.name}`}
           onChange={(event) => {
             const value = event.target.value;

--- a/src/pages/Assignments/tabs/TopicsTab.tsx
+++ b/src/pages/Assignments/tabs/TopicsTab.tsx
@@ -56,6 +56,19 @@ interface TopicData {
   updatedAt?: string;
 }
 
+interface RubricOption {
+  label: string;
+  value: number;
+}
+
+interface TopicRubricMapping {
+  id: number;
+  questionnaire_id: number;
+  questionnaire_name?: string;
+  project_topic_id: number | null;
+  used_in_round: number | null;
+}
+
 // Same as before
 interface TopicSettings {
   allowTopicSuggestions: boolean;
@@ -74,6 +87,11 @@ interface TopicsTabProps {
   topicsData: TopicData[]; // Ensure the data passed matches the updated TopicData interface
   topicsLoading?: boolean;
   topicsError?: string | null;
+  varyByTopic?: boolean;
+  varyByRound?: boolean;
+  reviewRounds?: number;
+  reviewRubricOptions?: RubricOption[];
+  topicRubricMappings?: TopicRubricMapping[];
   onTopicSettingChange: (setting: string, value: boolean) => void;
   // Add handlers for actions like drop team, delete topic, edit topic, create bookmark etc.
   onDropTeam: (topicId: string, teamId: string) => void;
@@ -82,6 +100,7 @@ interface TopicsTabProps {
   onCreateTopic?: (topicData: any) => void;
   // Handler for partner ad application submission
   onApplyPartnerAd: (topicId: string, applicationText: string) => void;
+  onTopicRubricChange?: (topicDatabaseId: number, questionnaireId: number | null, usedInRound: number | null) => void;
   onTopicsChanged?: () => void;
 }
 
@@ -94,12 +113,18 @@ const TopicsTab = ({
   topicsData,
   topicsLoading = false,
   topicsError = null,
+  varyByTopic = false,
+  varyByRound = false,
+  reviewRounds = 1,
+  reviewRubricOptions = [],
+  topicRubricMappings = [],
   onTopicSettingChange,
   onDropTeam,
   onDeleteTopic,
   onEditTopic,
   onCreateTopic,
   onApplyPartnerAd,
+  onTopicRubricChange,
   onTopicsChanged,
 }: TopicsTabProps) => {
   const [showPartnerAdModal, setShowPartnerAdModal] = useState(false);
@@ -311,6 +336,51 @@ const TopicsTab = ({
   const questionnaireVaries = topicsData.length > 0 &&
     topicsData.some(t => t.questionnaire !== topicsData[0].questionnaire);
 
+  const rubricRounds = varyByRound
+    ? Array.from({ length: Math.max(reviewRounds || 1, 1) }, (_, index) => index + 1)
+    : [null];
+
+  const findTopicRubricMapping = (topicDatabaseId?: number, usedInRound?: number | null) => {
+    if (!topicDatabaseId) return undefined;
+
+    return topicRubricMappings.find((mapping) =>
+      Number(mapping.project_topic_id) === Number(topicDatabaseId) &&
+      (mapping.used_in_round ?? null) === (usedInRound ?? null)
+    );
+  };
+
+  const renderRubricSelector = (topic: TopicData, usedInRound: number | null) => {
+    const mapping = findTopicRubricMapping(topic.databaseId, usedInRound);
+    const label = usedInRound ? `Round ${usedInRound}` : "Rubric";
+
+    return (
+      <div key={`${topic.databaseId}-${usedInRound ?? "default"}`} className="mb-2">
+        {varyByRound && <div className="small text-muted mb-1">{label}</div>}
+        <Form.Select
+          size="sm"
+          value={mapping?.questionnaire_id ?? ""}
+          disabled={reviewRubricOptions.length === 0}
+          aria-label={`${label} for ${topic.name}`}
+          onChange={(event) => {
+            const value = event.target.value;
+            onTopicRubricChange?.(
+              topic.databaseId,
+              value ? Number(value) : null,
+              usedInRound
+            );
+          }}
+        >
+          <option value="">Use assignment default rubric</option>
+          {reviewRubricOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </Form.Select>
+      </div>
+    );
+  };
+
   // --- Render Helper Functions ---
   // removed: renderTeamMembers (moved to TopicsTable renderDetails inline rendering)
 
@@ -408,6 +478,24 @@ const TopicsTab = ({
           onToggleAll={handleSelectAll}
           onToggleRow={handleSelectTopic}
           extraColumns={[
+            ...(varyByTopic
+              ? [
+                  {
+                    id: "topicReviewRubric",
+                    header: varyByRound ? "Review Rubrics by Round" : "Review Rubric",
+                    cell: ({ row }: any) => {
+                      const topic = topicsData.find(t => t.id === row.original.id);
+                      if (!topic) return null;
+
+                      return (
+                        <div style={{ minWidth: varyByRound ? 260 : 220 }}>
+                          {rubricRounds.map((round) => renderRubricSelector(topic, round))}
+                        </div>
+                      );
+                    },
+                  },
+                ]
+              : []),
             ...(questionnaireVaries //displays the questionnaire column only if it varies across the topics
               ? [
                   {

--- a/src/pages/Questionnaires/Questionnaire.tsx
+++ b/src/pages/Questionnaires/Questionnaire.tsx
@@ -53,14 +53,13 @@ const Questionnaires = () => {
   );
 
   const onDeleteHandle = useCallback(
-     (row: TRow<QuestionnaireResponse>) => {
-    console.log("Delete clicked:", row.original);
-    setSelectedQuestionnaire(null);
-    setTimeout(() => {
-      setShowDeleteConfirmation({ visible: true, data: row.original });
-    }, 100);
-  },
-  []
+    (row: TRow<QuestionnaireResponse>) => {
+      setSelectedQuestionnaire(null);
+      setTimeout(() => {
+        setShowDeleteConfirmation({ visible: true, data: row.original });
+      }, 100);
+    },
+    []
   );
   
   

--- a/src/pages/Questionnaires/Questionnaire.tsx
+++ b/src/pages/Questionnaires/Questionnaire.tsx
@@ -48,7 +48,7 @@ const Questionnaires = () => {
   const onDeleteQuestionnaireHandler = useCallback(() => setShowDeleteConfirmation({ visible: false }), []);
 
   const onEditHandle = useCallback(
-    (row: TRow<QuestionnaireResponse>) => navigate(`edit/${row.original.id}`),
+    (row: TRow<QuestionnaireResponse>) => navigate(`/questionnaires/edit/${row.original.id}`),
     [navigate]
   );
 

--- a/src/pages/Questionnaires/QuestionnaireForm.tsx
+++ b/src/pages/Questionnaires/QuestionnaireForm.tsx
@@ -2,6 +2,7 @@
   import { Formik, Field, Form, ErrorMessage } from "formik";
   import { Button } from 'react-bootstrap';
   import QuestionnaireItemsFieldArray from "./QuestionnaireItemsFieldArray";
+  import { QuestionItemTypes } from "./QuestionnaireUtils";
   import * as Yup from "yup";
   import useAPI from "hooks/useAPI";
 
@@ -9,11 +10,14 @@
   const QuestionnaireForm = ({ initialValues, onSubmit }: any) => {
 
     const { data: itemTypes, sendRequest: fetchItemTypes } = useAPI();
+    const availableItemTypes = (itemTypes?.data?.map((t: any) => t.name) as string[])?.length
+      ? (itemTypes.data.map((t: any) => t.name) as string[])
+      : QuestionItemTypes;
   
 
     useEffect(() => {
           
-            fetchItemTypes({ url: "/item_types" });
+            fetchItemTypes({ url: "/questions/types" });
           console.log(itemTypes?.data);
         }, [fetchItemTypes]);
       
@@ -177,7 +181,12 @@
 
 
             {/* Allows users to input a variable number of questions / items */}
-            <QuestionnaireItemsFieldArray values={values} errors={errors} touched={touched} itemTypes={(itemTypes?.data?.map((t: any) => t.name) as string[]) ?? []} />
+            <QuestionnaireItemsFieldArray
+              values={values}
+              errors={errors}
+              touched={touched}
+              itemTypes={availableItemTypes}
+            />
 
             <br />
             <Button type="submit" variant="primary">

--- a/src/pages/Questionnaires/QuestionnaireForm.tsx
+++ b/src/pages/Questionnaires/QuestionnaireForm.tsx
@@ -16,10 +16,8 @@
   
 
     useEffect(() => {
-          
-            fetchItemTypes({ url: "/questions/types" });
-          console.log(itemTypes?.data);
-        }, [fetchItemTypes]);
+      fetchItemTypes({ url: "/questions/types" });
+    }, [fetchItemTypes]);
       
 
     const itemFields = Yup.object().shape({

--- a/src/pages/Questionnaires/QuestionnaireUtils.test.ts
+++ b/src/pages/Questionnaires/QuestionnaireUtils.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+
+import { QuestionnaireTypes, transformQuestionnaireRequest } from "./QuestionnaireUtils";
+
+describe("Questionnaire type mappings", () => {
+  it("includes Review in the questionnaire type list", () => {
+    expect(QuestionnaireTypes).toContain("Review");
+  });
+
+  it("builds create payloads with backend questionnaire types", () => {
+    const payload = transformQuestionnaireRequest({
+      name: "Security Review Rubric",
+      questionnaire_type: "Review",
+      private: false,
+      min_question_score: 0,
+      max_question_score: 5,
+      items: [],
+    });
+
+    expect(payload.questionnaire.questionnaire_type).toBe("ReviewQuestionnaire");
+  });
+});

--- a/src/pages/Questionnaires/QuestionnaireUtils.test.ts
+++ b/src/pages/Questionnaires/QuestionnaireUtils.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { QuestionnaireTypes, transformQuestionnaireRequest } from "./QuestionnaireUtils";
+import {
+  QuestionnaireTypes,
+  transformQuestionnaireRequest,
+  transformQuestionnaireResponse,
+} from "./QuestionnaireUtils";
 
 describe("Questionnaire type mappings", () => {
   it("includes Review in the questionnaire type list", () => {
@@ -18,5 +22,19 @@ describe("Questionnaire type mappings", () => {
     });
 
     expect(payload.questionnaire.questionnaire_type).toBe("ReviewQuestionnaire");
+  });
+
+  it("normalizes backend review questionnaire types for edit forms", () => {
+    const values = transformQuestionnaireResponse({
+      id: 1,
+      name: "Security Review Rubric",
+      questionnaire_type: "ReviewQuestionnaire",
+      private: false,
+      min_question_score: 0,
+      max_question_score: 5,
+      items: [],
+    });
+
+    expect(values.questionnaire_type).toBe("Review");
   });
 });

--- a/src/pages/Questionnaires/QuestionnaireUtils.tsx
+++ b/src/pages/Questionnaires/QuestionnaireUtils.tsx
@@ -126,12 +126,15 @@ export const transformQuestionnaireRequest = (values: QuestionnaireFormValues) =
   return { questionnaire };
 };
 
+const normalizeQuestionnaireType = (questionnaireType: string) =>
+  questionnaireType === "ReviewQuestionnaire" ? "Review" : questionnaireType;
+
 export const transformQuestionnaireResponse = (data: any): QuestionnaireFormValues => {
   return {
     id: data.id,
     name: data.name,
     private: data.private,
-    questionnaire_type: data.questionnaire_type,
+    questionnaire_type: normalizeQuestionnaireType(data.questionnaire_type),
     min_question_score: data.min_question_score,
     max_question_score: data.max_question_score,
     instructor_id: data.instructor_id,

--- a/src/pages/Questionnaires/QuestionnaireUtils.tsx
+++ b/src/pages/Questionnaires/QuestionnaireUtils.tsx
@@ -2,6 +2,7 @@ import axiosClient from "../../utils/axios_client";
 import { IInstructor } from "../../utils/interfaces";
 
 export type QuestionnaireType =
+  | "Review"
   | "Author feedback"
   | "Teammate Review"
   | "Survey"
@@ -11,8 +12,8 @@ export type QuestionnaireType =
   | "Bookmark rating"
   | "Quiz";
 
-
 export const QuestionnaireTypes: QuestionnaireType[] = [
+  "Review",
   "Author feedback",
   "Teammate Review",
   "Survey",
@@ -21,6 +22,16 @@ export const QuestionnaireTypes: QuestionnaireType[] = [
   "Course survey",
   "Bookmark rating",
   "Quiz",
+];
+
+export const QuestionItemTypes: string[] = [
+  "Criterion",
+  "Scale",
+  "Multiple choice",
+  "Dropdown",
+  "Text field",
+  "Text area",
+  "Grid",
 ];
 
 
@@ -98,7 +109,9 @@ export const transformQuestionnaireRequest = (values: QuestionnaireFormValues) =
   const questionnaire: QuestionnaireRequest = {
     id: values.id,
     name: values.name,
-    questionnaire_type: values.questionnaire_type.replace(/\s+/g, ""),
+    questionnaire_type: values.questionnaire_type === "Review"
+      ? "ReviewQuestionnaire"
+      : values.questionnaire_type.replace(/\s+/g, ""),
     private: values.private,
     min_question_score: values.min_question_score,
     max_question_score: values.max_question_score,

--- a/src/pages/Questionnaires/QuestionnaireUtils.tsx
+++ b/src/pages/Questionnaires/QuestionnaireUtils.tsx
@@ -105,7 +105,6 @@ export function getQuestionnaireTypes(quest: QuestionnaireResponse[]): string[] 
 
 
 export const transformQuestionnaireRequest = (values: QuestionnaireFormValues) => {
-  console.log("Original Form Values:", values);
   const questionnaire: QuestionnaireRequest = {
     id: values.id,
     name: values.name,
@@ -124,7 +123,6 @@ export const transformQuestionnaireRequest = (values: QuestionnaireFormValues) =
         }))
       : [],
   };
-  console.log("Transformed Questionnaire Request:", questionnaire);
   return { questionnaire };
 };
 

--- a/src/pages/Reviews/reviews.tsx
+++ b/src/pages/Reviews/reviews.tsx
@@ -1,13 +1,22 @@
 import { Table } from "react-bootstrap";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import "./Reviews.css";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import { getReviewItems, getFeedbackItems, ReviewItem } from "./reviewData"; // Import function and interface
+import useAPI from "../../hooks/useAPI";
 
 import { Row, Col, Button, Modal } from "react-bootstrap";
 import { BsEnvelopeFill, BsEyeFill, BsEyeSlashFill, BsShareFill, BsTrashFill, BsCheck, BsX, BsFileEarmarkArrowUp} from "react-icons/bs";
 
 type HandleMethod = () => void;
+
+interface ResolvedRubric {
+  assignment_questionnaire_id: number;
+  questionnaire_id: number;
+  questionnaire_name?: string;
+  project_topic_id?: number | null;
+  used_in_round?: number | null;
+}
 
 const Reviews: React.FC = () => {
   const [showReview, setShowReview] = useState<boolean>(true);
@@ -15,10 +24,15 @@ const Reviews: React.FC = () => {
   const [showSubmissions, setshowSubmissions] = useState<boolean>(true);
 
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const responseMapId = searchParams.get("response_map_id");
+  const reviewRound = searchParams.get("round");
+  const { data: rubricResponse, error: rubricError, sendRequest: fetchResolvedRubric } = useAPI();
   const [reviewSetId, setReviewSetId] = useState<string>("1"); // Default set ID
   const [reviewItems, setReviewItems] = useState<ReviewItem[]>([]);
   const [feedbackItems, setFeedbackItems] = useState<ReviewItem[]>([]);
   const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [resolvedRubric, setResolvedRubric] = useState<ResolvedRubric | null>(null);
 
   const [showWarning, setShowWarning] = useState(false);
   const [warningSuccessFunc, setWarningSuccessFunc] = useState<HandleMethod | null>(null);
@@ -71,6 +85,25 @@ const Reviews: React.FC = () => {
     setFeedbackItems(feedback);
   }, [reviewSetId]);  // Make sure reviewSetId is managed correctly
 
+  useEffect(() => {
+    if (!responseMapId) return;
+
+    fetchResolvedRubric({
+      url: "/student_tasks/rubric_for",
+      method: "GET",
+      params: {
+        response_map_id: responseMapId,
+        ...(reviewRound ? { round: reviewRound } : {}),
+      },
+    });
+  }, [fetchResolvedRubric, responseMapId, reviewRound]);
+
+  useEffect(() => {
+    if (rubricResponse?.data) {
+      setResolvedRubric(rubricResponse.data);
+    }
+  }, [rubricResponse]);
+
   if (!reviewItems.length) {
     console.log('No review items to display');
     return <div>No reviews available.</div>;
@@ -121,6 +154,28 @@ const Reviews: React.FC = () => {
   return (
     <div className="centered-container">
       <h1>Review for Program 2</h1>
+      {responseMapId && (
+        <div className={rubricError ? "alert alert-warning" : "alert alert-info"} role="status">
+          {rubricError ? (
+            <>
+              <strong>Rubric lookup failed:</strong> {rubricError}
+            </>
+          ) : resolvedRubric ? (
+            <>
+              <strong>Resolved review rubric:</strong>{" "}
+              {resolvedRubric.questionnaire_name || `Questionnaire ${resolvedRubric.questionnaire_id}`}
+              {resolvedRubric.project_topic_id && (
+                <span> for topic #{resolvedRubric.project_topic_id}</span>
+              )}
+              {resolvedRubric.used_in_round && (
+                <span> in round {resolvedRubric.used_in_round}</span>
+              )}
+            </>
+          ) : (
+            <>Loading resolved review rubric...</>
+          )}
+        </div>
+      )}
       <br/>
       <Modal show={showWarning} onHide={handleCloseWarning}>
         <Modal.Header closeButton>

--- a/src/pages/Reviews/reviews.tsx
+++ b/src/pages/Reviews/reviews.tsx
@@ -78,7 +78,6 @@ const Reviews: React.FC = () => {
   }
 
   useEffect(() => {
-    console.log('Component mounted or reviewSetId changed');
     const items = getReviewItems(reviewSetId);
     const feedback = getFeedbackItems(reviewSetId);
     setReviewItems(items);
@@ -105,7 +104,6 @@ const Reviews: React.FC = () => {
   }, [rubricResponse]);
 
   if (!reviewItems.length) {
-    console.log('No review items to display');
     return <div>No reviews available.</div>;
   }
 
@@ -123,7 +121,6 @@ const Reviews: React.FC = () => {
   };
 
   const handleShareReview = () => {
-    console.log("Handle Share Review");
   };
 
   const getScoreColor = (score: number) => {

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -159,6 +159,7 @@ export interface IAssignmentRequest {
 
   // Per-round rubric configuration
   vary_by_round?: boolean;
+  vary_by_topic?: boolean;
   rounds_of_reviews?: number;
   assignment_questionnaires_attributes?: {
     id?: number;
@@ -253,6 +254,7 @@ export interface IAssignmentResponse {
   staggered_deadline:boolean;
   is_calibrated:boolean;
   vary_by_round?: boolean;
+  vary_by_topic?: boolean;
   varying_rubrics_by_round?: boolean;
   rounds_of_reviews?: number;
   due_dates?: { id: number; deadline_type_id: number }[];


### PR DESCRIPTION
## Summary

This PR completes the frontend support for specialized rubrics by topic in the assignment editor.

It adds the UI and request handling needed for instructors to:
- enable `Review rubric varies by topic?`
- view review-rubric selectors for each topic in the `Topics` tab
- assign a different review rubric to each topic
- preserve the assignment-level review rubric as the default fallback when no topic-specific override is selected

## Changes

- persist `vary_by_topic` state in the assignment editor
- load topic-specific rubric mappings from the backend when editing an assignment
- render per-topic review rubric dropdowns in the `Topics` tab when topic-specific rubrics are enabled
- support the combined topic + round case by rendering one rubric selector per topic per round when applicable
- save topic-specific rubric selections back to the backend through the topic-rubric API flow
- align assignment editor request/response handling with the backend rubric-by-topic contract
- include a small questionnaire form fix so locally created questionnaires/rubrics can be submitted correctly during manual testing

## Behavior

After this change, the assignment editor supports all expected rubric-selection cases:
- rubric does not vary by round or topic
- rubric varies by round only
- rubric varies by topic only
- rubric varies by both round and topic

When `Review rubric varies by topic?` is enabled:
- each topic gets its own review-rubric selector
- the selected topic rubric overrides the assignment default
- topics without an override continue using the default assignment review rubric

Manual verification:
- enabled topic-specific rubrics in the assignment editor
- created topics
- selected different rubrics per topic
- reloaded the page and confirmed selections persisted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assignments can vary review rubrics by topic (and by round) with per-topic questionnaire selectors
  * Added "Review" questionnaire type and improved questionnaire item-type handling
  * Rubric details now display on the Reviews page when referenced via URL parameters

* **Bug Fixes**
  * Rubric weight validation ignores empty inputs; rubric selector disables while a per-topic mapping save is pending; clearer save alerts

* **Tests**
  * Added tests for topic-based rubric mappings and questionnaire type mappings

* **Chores**
  * Updated .gitignore to exclude dist directory
<!-- end of auto-generated comment: release notes by coderabbit.ai -->