### PR TITLE
Unified Login Response

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import ViewScores from "./pages/Assignments/ViewScores";
 import ViewSubmissions from "./pages/Assignments/ViewSubmissions";
 import SubmittedContent from "./pages/Assignments/SubmittedContent";
 import Login from "./pages/Authentication/Login";
+import OidcCallback from "./pages/OidcCallback/OidcCallback";
 import Logout from "./pages/Authentication/Logout";
 import Courses from "./pages/Courses/Course";
 import CourseEditor from "./pages/Courses/CourseEditor";
@@ -63,6 +64,7 @@ function App() {
       children: [
         { index: true, element: <ProtectedRoute element={<Home />} /> },
         { path: "login", element: <Login /> },
+        { path: "auth/callback", element: <OidcCallback /> },
         { path: "logout", element: <ProtectedRoute element={<Logout />} /> },
 
         {
@@ -85,7 +87,7 @@ function App() {
           loader: loadAssignment,
         },
 
-        // Assign Reviewer: no route loader (component handles localStorage/URL id) 
+        // Assign Reviewer: no route loader (component handles localStorage/URL id)
         {
           path: "assignments/edit/:id/responsemappings",
           element: <ResponseMappings />,
@@ -350,7 +352,7 @@ function App() {
                   path: "new",
                   element: <RoleEditor mode="create" />,
                 },
-                                {
+                {
                   id: "edit-role",
                   path: "edit/:id",
                   element: <RoleEditor mode="update" />,
@@ -363,11 +365,11 @@ function App() {
               element: <Institutions />,
               loader: loadInstitutions,
               children: [
-               {
+                {
                   path: "new",
                   element: <InstitutionEditor mode="create" />,
                 },
-                                {
+                {
                   path: "edit/:id",
                   element: <InstitutionEditor mode="update" />,
                   loader: loadInstitution,
@@ -379,7 +381,7 @@ function App() {
               element: <ManageUserTypes />,
               loader: loadUsers,
               children: [
-                 {
+                {
                   path: "new",
                   element: <Navigate to="/users/new" />,
                 },
@@ -390,29 +392,42 @@ function App() {
                 },
               ],
             },
-            { 
-              path: "questionnaire", 
-              element: <Questionnaire />, 
-              loader: loadQuestionnaire, },
-                      ],
+            {
+              path: "questionnaire",
+              element: <Questionnaire />,
+              loader: loadQuestionnaire,
+            },
+          ],
         },
 
-       { path: "*", element: <NotFound /> },
+        { path: "*", element: <NotFound /> },
         { path: "questionnaire", element: <Questionnaire />, loader: loadQuestionnaire },
 
         {
           path: "questionnaires",
-          element: <ProtectedRoute element={<Questionnaire />} leastPrivilegeRole={ROLE.INSTRUCTOR} />,
+          element: (
+            <ProtectedRoute element={<Questionnaire />} leastPrivilegeRole={ROLE.INSTRUCTOR} />
+          ),
           loader: loadQuestionnaire,
         },
         {
           path: "questionnaires/new",
-          element: <ProtectedRoute element={<QuestionnaireEditor mode="create" />} leastPrivilegeRole={ROLE.INSTRUCTOR} />,
+          element: (
+            <ProtectedRoute
+              element={<QuestionnaireEditor mode="create" />}
+              leastPrivilegeRole={ROLE.INSTRUCTOR}
+            />
+          ),
           loader: loadQuestionnaire,
         },
         {
           path: "questionnaires/edit/:id",
-          element: <ProtectedRoute element={<QuestionnaireEditor mode="update" />} leastPrivilegeRole={ROLE.INSTRUCTOR} />,
+          element: (
+            <ProtectedRoute
+              element={<QuestionnaireEditor mode="update" />}
+              leastPrivilegeRole={ROLE.INSTRUCTOR}
+            />
+          ),
           loader: loadQuestionnaire,
         },
       ],

--- a/src/components/OidcLogin/OidcLogin.tsx
+++ b/src/components/OidcLogin/OidcLogin.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from "react";
+import { Form } from "react-bootstrap";
+import axios from "axios";
+
+interface OidcProvider {
+  id: string;
+  name: string;
+}
+
+const OidcLogin: React.FC = () => {
+  const [providers, setProviders] = useState<OidcProvider[]>([]);
+
+  useEffect(() => {
+    axios
+      .get("http://localhost:3002/auth/providers")
+      .then((response) => setProviders(response.data))
+      .catch(() => setProviders([]));
+  }, []);
+
+  const handleLogin = (providerId: string) => {
+    axios
+      .post("http://localhost:3002/auth/client-select", { provider: providerId })
+      .then((response) => {
+        window.location.href = response.data.redirect_uri;
+      })
+      .catch((error) => {
+        console.error("Failed to initiate OIDC login:", error);
+      });
+  };
+
+  if (providers.length === 0) return null;
+
+  return (
+    <div className="mt-3">
+      <hr />
+      <Form.Select
+        defaultValue=""
+        onChange={(e) => {
+          if (e.target.value) handleLogin(e.target.value);
+        }}
+      >
+        <option value="" disabled>
+          Sign in with...
+        </option>
+        {providers.map((provider) => (
+          <option key={provider.id} value={provider.id}>
+            {provider.name}
+          </option>
+        ))}
+      </Form.Select>
+    </div>
+  );
+};
+
+export default OidcLogin;

--- a/src/pages/Authentication/Login.tsx
+++ b/src/pages/Authentication/Login.tsx
@@ -9,6 +9,7 @@ import { alertActions } from "../../store/slices/alertSlice";
 import { setAuthToken } from "../../utils/auth";
 import * as Yup from "yup";
 import axios from "axios";
+import OidcLogin from "../../components/OidcLogin/OidcLogin";
 
 /**
  * @author Ankur Mundra on June, 2023
@@ -98,6 +99,7 @@ const Login: React.FC = () => {
             );
           }}
         </Formik>
+        <OidcLogin />
       </Col>
     </Container>
   );

--- a/src/pages/OidcCallback/OidcCallback.tsx
+++ b/src/pages/OidcCallback/OidcCallback.tsx
@@ -37,7 +37,7 @@ const OidcCallback: React.FC = () => {
     axios
       .post("http://localhost:3002/auth/callback", { code, state })
       .then((response) => {
-        const payload = setAuthToken(response.data.session_token);
+        const payload = setAuthToken(response.data.token);
 
         localStorage.setItem("session", JSON.stringify({ user: payload }));
 

--- a/src/pages/OidcCallback/OidcCallback.tsx
+++ b/src/pages/OidcCallback/OidcCallback.tsx
@@ -1,0 +1,71 @@
+import React, { useEffect } from "react";
+import { useNavigate, useSearchParams, useLocation } from "react-router-dom";
+import { useDispatch } from "react-redux";
+import { authenticationActions } from "../../store/slices/authenticationSlice";
+import { alertActions } from "../../store/slices/alertSlice";
+import { setAuthToken } from "../../utils/auth";
+import axios from "axios";
+
+const OidcCallback: React.FC = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const location = useLocation();
+
+  useEffect(() => {
+    const code = searchParams.get("code");
+    const state = searchParams.get("state");
+    const error = searchParams.get("error");
+
+    if (error) {
+      dispatch(
+        alertActions.showAlert({
+          variant: "danger",
+          message: `Authentication was denied: ${error}`,
+          title: "OIDC login failed",
+        })
+      );
+      navigate("/login");
+      return;
+    }
+
+    if (!code || !state) {
+      navigate("/login");
+      return;
+    }
+
+    axios
+      .post("http://localhost:3002/auth/callback", { code, state })
+      .then((response) => {
+        const payload = setAuthToken(response.data.session_token);
+
+        localStorage.setItem("session", JSON.stringify({ user: payload }));
+
+        dispatch(
+          authenticationActions.setAuthentication({
+            authToken: response.data.session_token,
+            user: payload,
+          })
+        );
+        navigate(location.state?.from ? location.state.from : "/");
+      })
+      .catch((error) => {
+        dispatch(
+          alertActions.showAlert({
+            variant: "danger",
+            message: error.response?.data?.error || error.message,
+            title: "OIDC login failed",
+          })
+        );
+        navigate("/login");
+      });
+  }, []);
+
+  return (
+    <div className="d-flex justify-content-center mt-5">
+      <p>Completing login...</p>
+    </div>
+  );
+};
+
+export default OidcCallback;


### PR DESCRIPTION
As a developer, I want the session object returned to the frontend clearly defined and reusable by all login flows, so that the frontend can rely on a consistent response shape regardless of authentication method.

Acceptance Criteria:

Extract the JWT payload construction and token issuance logic from AuthenticationController#login and OidcLoginController#callback into a shared method on the User model (e.g. user.generate_jwt).
Define a consistent response structure (e.g. { token, user: { id, name, full_name, role, institution_id } }) and use it in both controllers.
Update the existing password login endpoint to use the shared method without changing its external response shape.
Add or update request specs for both login endpoints to assert the response structure matches.