### PR TITLE
E2612 - course based reports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import Login from "./pages/Authentication/Login";
 import Logout from "./pages/Authentication/Logout";
 import Courses from "./pages/Courses/Course";
 import CourseEditor from "./pages/Courses/CourseEditor";
+import CourseReport from "./pages/Courses/CourseReport";
 import { loadCourseInstructorDataAndInstitutions } from "./pages/Courses/CourseUtil";
 import Questionnaire from "./pages/Questionnaires/Questionnaire";
 import QuestionnaireEditor from "./pages/Questionnaires/QuestionnaireEditor";
@@ -340,6 +341,10 @@ function App() {
                   loader: loadTAs,
                 },
               ],
+            },
+            {
+              path: ":courseId/class_assignment_overview",
+              element: <ProtectedRoute element={<CourseReport />} leastPrivilegeRole={ROLE.TA} />,
             },
           ],
         },

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -27,6 +27,7 @@ interface TableProps {
   showGlobalFilter?: boolean;
   showColumnFilter?: boolean;
   showPagination?: boolean;
+  disablePaginationRowModel?: boolean;
   tableSize?: { span: number; offset: number };
   columnVisibility?: Record<string, boolean>;
   onSelectionChange?: (selectedData: Record<any, any>[]) => void;
@@ -42,6 +43,7 @@ const Table: React.FC<TableProps> = ({
   showGlobalFilter = false,
   showColumnFilter = true,
   showPagination = true,
+  disablePaginationRowModel = false,
   onSelectionChange,
    onRowClick,
   columnVisibility = {},
@@ -141,7 +143,7 @@ const Table: React.FC<TableProps> = ({
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
+    getPaginationRowModel: disablePaginationRowModel ? undefined : getPaginationRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
   });
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -24,6 +24,7 @@ interface TableProps {
   data: Record<string, any>[];
   columns: ColumnDef<any, any>[];
   disableGlobalFilter?: boolean;
+  disablePaginationRowModel?: boolean;
   showGlobalFilter?: boolean;
   showColumnFilter?: boolean;
   showPagination?: boolean;

--- a/src/pages/Courses/Course.test.tsx
+++ b/src/pages/Courses/Course.test.tsx
@@ -1,0 +1,136 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import Courses from "./Course";
+
+const mockUseLocation = vi.fn();
+const mockNavigate = vi.fn();
+const mockDispatch = vi.fn();
+const mockUseAPI = vi.fn();
+const mockTable = vi.fn();
+
+vi.mock("react-router-dom", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-router-dom")>()),
+  useNavigate: () => mockNavigate,
+  useLocation: () => mockUseLocation(),
+  Outlet: () => <div data-testid="courses-outlet" />,
+}));
+
+vi.mock("react-redux", () => ({
+  useDispatch: () => mockDispatch,
+  useSelector: (selector: any) =>
+    selector({
+      authentication: {
+        isAuthenticated: true,
+        user: {
+          id: 7,
+          full_name: "Taylor Teach",
+          role: "Instructor",
+        },
+      },
+    }),
+}));
+
+vi.mock("../../hooks/useAPI", () => ({
+  default: () => mockUseAPI(),
+}));
+
+vi.mock("components/Table/Table", () => ({
+  default: (props: any) => {
+    mockTable(props);
+    return <div data-testid="courses-table" />;
+  },
+}));
+
+vi.mock("./CourseDelete", () => ({
+  default: () => <div>Delete Course Modal</div>,
+}));
+
+vi.mock("./CourseCopy", () => ({
+  default: () => <div>Copy Course Modal</div>,
+}));
+
+vi.mock("./CourseAssignments", () => ({
+  default: () => <div>Course Assignments</div>,
+}));
+
+const setUseApiSequence = () => {
+  mockUseAPI
+    .mockReturnValueOnce({
+      error: "",
+      isLoading: false,
+      data: {
+        data: [
+          {
+            id: 1,
+            name: "CSC 517",
+            directory_path: "csc517",
+            info: "Course info",
+            private: true,
+            created_at: "2024-01-01T00:00:00.000Z",
+            updated_at: "2024-01-02T00:00:00.000Z",
+            institution_id: 1,
+            instructor_id: 7,
+            institution: { id: 1, name: "NCSU" },
+            instructor: { id: 7, name: "Taylor Teach" },
+            date_format_pref: "MM/DD/YYYY",
+          },
+        ],
+      },
+      sendRequest: vi.fn(),
+    })
+    .mockReturnValueOnce({
+      data: { data: [{ id: 1, name: "NCSU" }] },
+      sendRequest: vi.fn(),
+    })
+    .mockReturnValueOnce({
+      data: { data: [{ id: 7, name: "Taylor Teach" }] },
+      sendRequest: vi.fn(),
+    })
+    .mockReturnValueOnce({
+      data: { data: [{ course_id: 1 }] },
+      sendRequest: vi.fn(),
+    });
+};
+
+describe("Courses report route behavior", () => {
+  beforeEach(() => {
+    mockUseLocation.mockReturnValue({
+      pathname: "/courses",
+      search: "",
+      hash: "",
+    });
+    mockUseAPI.mockReset();
+    mockTable.mockReset();
+    setUseApiSequence();
+  });
+
+  it("renders only the outlet when the current path is the course report page", () => {
+    mockUseLocation.mockReturnValue({
+      pathname: "/courses/1/class_assignment_overview",
+      search: "",
+      hash: "",
+    });
+
+    render(<Courses />);
+
+    expect(screen.getByTestId("courses-outlet")).toBeInTheDocument();
+    expect(screen.queryByTestId("courses-table")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Manage Courses/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the normal courses page when the current path is not the report page", () => {
+    render(<Courses />);
+
+    expect(screen.getByTestId("courses-outlet")).toBeInTheDocument();
+    expect(screen.getByTestId("courses-table")).toBeInTheDocument();
+    expect(screen.getByText("Instructed by: Taylor Teach")).toBeInTheDocument();
+  });
+
+  it("passes course rows to the shared table on the normal courses page", async () => {
+    render(<Courses />);
+
+    await waitFor(() => expect(mockTable).toHaveBeenCalledTimes(1));
+    expect(mockTable.mock.calls[0][0].data).toHaveLength(1);
+    expect(mockTable.mock.calls[0][0].data[0].name).toBe("CSC 517");
+  });
+});

--- a/src/pages/Courses/Course.tsx
+++ b/src/pages/Courses/Course.tsx
@@ -33,6 +33,7 @@ const Courses = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const dispatch = useDispatch();
+  const isReportPage = location.pathname.includes("class_assignment_overview");
 
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState<{
     visible: boolean;
@@ -167,6 +168,10 @@ const renderSubComponent = useCallback(({ row }: { row: TRow<ICourseResponse> })
     if (!assignmentResponse?.data) return new Set();
     return new Set(assignmentResponse.data.map((a: any) => a.course_id));
   }, [assignmentResponse?.data]);
+
+  if (isReportPage) {
+    return <Outlet />;
+  }
 
   return (
     <>

--- a/src/pages/Courses/Course.tsx
+++ b/src/pages/Courses/Course.tsx
@@ -102,6 +102,11 @@ const Courses = () => {
     []
   );
 
+  const onReportHandle = useCallback(
+    (row: TRow<ICourseResponse>) => navigate(`${row.original.id}/class_assignment_overview`),
+    [navigate]
+  );
+
 const renderSubComponent = useCallback(({ row }: { row: TRow<ICourseResponse> }) => {
 	return (
 	  <CourseAssignments
@@ -112,8 +117,8 @@ const renderSubComponent = useCallback(({ row }: { row: TRow<ICourseResponse> })
   }, []);
 
   const tableColumns = useMemo(
-    () => COURSE_COLUMNS(onEditHandle, onDeleteHandle, onTAHandle, onCopyHandle),
-    [onDeleteHandle, onEditHandle, onTAHandle, onCopyHandle]
+    () => COURSE_COLUMNS(onEditHandle, onDeleteHandle, onTAHandle, onCopyHandle, onReportHandle),
+    [onDeleteHandle, onEditHandle, onTAHandle, onCopyHandle, onReportHandle]
   );
 
   const tableData = useMemo(

--- a/src/pages/Courses/CourseColumns.test.tsx
+++ b/src/pages/Courses/CourseColumns.test.tsx
@@ -1,0 +1,77 @@
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { courseColumns } from "./CourseColumns";
+
+const mockRow = {
+  original: {
+    id: 15,
+    name: "CSC 517",
+    institution: { id: 1, name: "NCSU" },
+    instructor: { id: 2, name: "Prof. Lane" },
+    created_at: "2024-01-01T00:00:00.000Z",
+    updated_at: "2024-01-02T00:00:00.000Z",
+  },
+} as any;
+
+describe("courseColumns report action", () => {
+  const handleEdit = vi.fn();
+  const handleDelete = vi.fn();
+  const handleTA = vi.fn();
+  const handleCopy = vi.fn();
+  const handleReport = vi.fn();
+
+  const renderActionsCell = () => {
+    const columns = courseColumns(
+      handleEdit,
+      handleDelete,
+      handleTA,
+      handleCopy,
+      handleReport
+    );
+    const actionsColumn = columns.find((column: any) => column.id === "actions") as any;
+
+    return render(actionsColumn.cell({ row: mockRow }));
+  };
+
+  beforeEach(() => {
+    handleEdit.mockReset();
+    handleDelete.mockReset();
+    handleTA.mockReset();
+    handleCopy.mockReset();
+    handleReport.mockReset();
+  });
+
+  it("renders the report action with the existing tooltip text", async () => {
+    const user = userEvent.setup();
+
+    renderActionsCell();
+    const reportButton = screen.getByRole("button", { name: "View Course Report" });
+
+    await user.hover(reportButton);
+
+    expect(await screen.findByText("View Course Report")).toBeInTheDocument();
+  });
+
+  it("calls handleReport with the clicked row", async () => {
+    const user = userEvent.setup();
+
+    renderActionsCell();
+    await user.click(screen.getByRole("button", { name: "View Course Report" }));
+
+    expect(handleReport).toHaveBeenCalledWith(mockRow);
+  });
+
+  it("renders the report action as a brown rectangular button instead of a link-style icon button", () => {
+    renderActionsCell();
+    const reportButton = screen.getByRole("button", { name: "View Course Report" });
+
+    expect(reportButton).toHaveStyle({
+      backgroundColor: "#8B4513",
+      borderColor: "#8B4513",
+      width: "25px",
+      height: "25px",
+    });
+    expect(reportButton).not.toHaveClass("btn-link");
+  });
+});

--- a/src/pages/Courses/CourseColumns.tsx
+++ b/src/pages/Courses/CourseColumns.tsx
@@ -1,5 +1,6 @@
 import { createColumnHelper, Row } from "@tanstack/react-table";
 import { Button, Tooltip, OverlayTrigger, Badge } from "react-bootstrap";
+import { BsBarChartFill } from "react-icons/bs";
 import { ICourseResponse as ICourse } from "../../utils/interfaces";
 import { formatDate } from "../../utils/util";
 
@@ -12,7 +13,8 @@ export const courseColumns = (
   handleEdit: Fn,
   handleDelete: Fn,
   handleTA: Fn,
-  handleCopy: Fn
+  handleCopy: Fn,
+  handleReport: Fn
 ) => [
   columnHelper.accessor("name", {
     id: "name",
@@ -204,6 +206,17 @@ export const courseColumns = (
               alt="Copy"
               style={{ width: "25px", height: "25px" }}
             />
+          </Button>
+        </OverlayTrigger>
+
+        <OverlayTrigger overlay={<Tooltip>View Course Report</Tooltip>}>
+          <Button
+            variant="link"
+            onClick={() => handleReport(row)}
+            aria-label="View Course Report"
+            className="p-0"
+          >
+            <BsBarChartFill size={20} color="#000000" />
           </Button>
         </OverlayTrigger>
       </div>

--- a/src/pages/Courses/CourseColumns.tsx
+++ b/src/pages/Courses/CourseColumns.tsx
@@ -1,6 +1,5 @@
 import { createColumnHelper, Row } from "@tanstack/react-table";
 import { Button, Tooltip, OverlayTrigger, Badge } from "react-bootstrap";
-import { BsBarChartFill } from "react-icons/bs";
 import { ICourseResponse as ICourse } from "../../utils/interfaces";
 import { formatDate } from "../../utils/util";
 
@@ -211,13 +210,16 @@ export const courseColumns = (
 
         <OverlayTrigger overlay={<Tooltip>View Course Report</Tooltip>}>
           <Button
-            variant="link"
+            style={{
+              backgroundColor: "#8B4513",
+              borderColor: "#8B4513",
+              width: "25px",
+              height: "25px",
+            }}
             onClick={() => handleReport(row)}
             aria-label="View Course Report"
             className="p-0"
-          >
-            <BsBarChartFill size={20} color="#000000" />
-          </Button>
+          />
         </OverlayTrigger>
       </div>
     ),

--- a/src/pages/Courses/CourseReport.test.tsx
+++ b/src/pages/Courses/CourseReport.test.tsx
@@ -1,0 +1,211 @@
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CourseReport from "./CourseReport";
+
+const mockUseParams = vi.fn();
+const mockSendRequest = vi.fn();
+const mockTable = vi.fn();
+const mockUseAPI = vi.fn();
+
+vi.mock("react-router-dom", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-router-dom")>()),
+  useParams: () => mockUseParams(),
+}));
+
+vi.mock("../../hooks/useAPI", () => ({
+  default: () => mockUseAPI(),
+}));
+
+vi.mock("../../components/Table/Table", () => ({
+  default: (props: any) => {
+    mockTable(props);
+    return (
+      <div data-testid="mock-table">
+        {Array.isArray(props.data) ? props.data.map((row: any) => row.studentName).join(", ") : ""}
+      </div>
+    );
+  },
+}));
+
+const reportResponse = {
+  course_id: 44,
+  course_name: "CSC 517",
+  assignments: [
+    {
+      assignment_id: 3,
+      assignment_name: "Project 1",
+      has_topics: true,
+    },
+    {
+      assignment_id: 5,
+      assignment_name: "Project 2",
+      has_topics: false,
+    },
+  ],
+  students: [
+    {
+      user_id: 1,
+      user_name: "Alice",
+      assignments: {
+        "3": {
+          participant_id: 101,
+          peer_grade: 88,
+          instructor_grade: 91,
+          avg_teammate_score: 77,
+          topic: "Topic A",
+        },
+        "5": null,
+      },
+    },
+    {
+      user_id: 2,
+      user_name: "Bob",
+      assignments: {
+        "3": {
+          participant_id: 102,
+          peer_grade: 92,
+          instructor_grade: null,
+          avg_teammate_score: 73,
+        },
+        "5": {
+          participant_id: 202,
+          peer_grade: 81,
+          instructor_grade: 84,
+          avg_teammate_score: 79,
+        },
+      },
+    },
+  ],
+};
+
+const setUseApiState = ({
+  data = { data: reportResponse },
+  error = "",
+  isLoading = false,
+} = {}) => {
+  mockUseAPI.mockReturnValue({
+    data,
+    error,
+    isLoading,
+    sendRequest: mockSendRequest,
+  });
+};
+
+describe("CourseReport", () => {
+  beforeEach(() => {
+    mockUseParams.mockReturnValue({ courseId: "44" });
+    mockSendRequest.mockReset();
+    mockTable.mockReset();
+    mockUseAPI.mockReset();
+    setUseApiState();
+  });
+
+  it("requests assignment records for the current course id", async () => {
+    render(<CourseReport />);
+
+    await waitFor(() =>
+      expect(mockSendRequest).toHaveBeenCalledWith({
+        url: "/assignment_records?course_id=44",
+      })
+    );
+  });
+
+  it("does not request data when the course id is missing", async () => {
+    mockUseParams.mockReturnValue({});
+
+    render(<CourseReport />);
+
+    await waitFor(() => expect(mockSendRequest).not.toHaveBeenCalled());
+  });
+
+  it("shows a spinner while the page is loading", () => {
+    setUseApiState({ isLoading: true, data: undefined });
+
+    render(<CourseReport />);
+
+    expect(document.querySelector(".spinner-border")).toBeInTheDocument();
+    expect(mockTable).not.toHaveBeenCalled();
+  });
+
+  it("shows an error alert when the request fails", () => {
+    setUseApiState({ error: "Unable to load report", data: undefined });
+
+    render(<CourseReport />);
+
+    expect(screen.getByText("Unable to load report")).toBeInTheDocument();
+    expect(mockTable).not.toHaveBeenCalled();
+  });
+
+  it("renders the course report title with the course name", () => {
+    render(<CourseReport />);
+
+    expect(screen.getByRole("heading", { name: "Course Report — CSC 517" })).toBeInTheDocument();
+  });
+
+  it("renders all report field checkboxes checked by default", () => {
+    render(<CourseReport />);
+
+    expect(screen.getByRole("checkbox", { name: "Topic" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Peer Grade" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Instructor Grade" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Avg. Teammate Score" })).toBeChecked();
+  });
+
+  it("passes the class average row to the first table and student rows to the second table", () => {
+    render(<CourseReport />);
+
+    expect(mockTable).toHaveBeenCalledTimes(2);
+    expect(mockTable.mock.calls[0][0].data).toHaveLength(1);
+    expect(mockTable.mock.calls[0][0].data[0].studentName).toBe("Class Average");
+    expect(mockTable.mock.calls[1][0].data.map((row: any) => row.studentName)).toEqual([
+      "Alice",
+      "Bob",
+    ]);
+  });
+
+  it("disables pagination and global filtering on both tables", () => {
+    render(<CourseReport />);
+
+    expect(mockTable).toHaveBeenCalledTimes(2);
+    mockTable.mock.calls.forEach(([props]: any[]) => {
+      expect(props.showPagination).toBe(false);
+      expect(props.showGlobalFilter).toBe(false);
+      expect(props.disablePaginationRowModel).toBe(true);
+    });
+  });
+
+  it("updates topic column visibility when the Topic checkbox is toggled off", async () => {
+    const user = userEvent.setup();
+
+    render(<CourseReport />);
+    mockTable.mockClear();
+
+    await user.click(screen.getByRole("checkbox", { name: "Topic" }));
+
+    await waitFor(() => expect(mockTable).toHaveBeenCalledTimes(2));
+    expect(mockTable.mock.calls[0][0].columnVisibility.a3_topic).toBe(false);
+    expect(mockTable.mock.calls[1][0].columnVisibility.a3_topic).toBe(false);
+  });
+
+  it("updates peer, instructor, and teammate column visibility when their checkboxes are toggled", async () => {
+    const user = userEvent.setup();
+
+    render(<CourseReport />);
+    mockTable.mockClear();
+
+    await user.click(screen.getByRole("checkbox", { name: "Peer Grade" }));
+    await user.click(screen.getByRole("checkbox", { name: "Instructor Grade" }));
+    await user.click(screen.getByRole("checkbox", { name: "Avg. Teammate Score" }));
+
+    await waitFor(() => expect(mockTable).toHaveBeenCalled());
+    const latestProps = mockTable.mock.calls.at(-1)?.[0];
+
+    expect(latestProps.columnVisibility.a3_peerGrade).toBe(false);
+    expect(latestProps.columnVisibility.a3_instructorGrade).toBe(false);
+    expect(latestProps.columnVisibility.a3_avgTeammateScore).toBe(false);
+    expect(latestProps.columnVisibility.a5_peerGrade).toBe(false);
+    expect(latestProps.columnVisibility.a5_instructorGrade).toBe(false);
+    expect(latestProps.columnVisibility.a5_avgTeammateScore).toBe(false);
+  });
+});

--- a/src/pages/Courses/CourseReport.test.tsx
+++ b/src/pages/Courses/CourseReport.test.tsx
@@ -53,6 +53,7 @@ const reportResponse = {
           peer_grade: 88,
           instructor_grade: 91,
           avg_teammate_score: 77,
+          avg_author_feedback_score: 82,
           topic: "Topic A",
         },
         "5": null,
@@ -67,12 +68,14 @@ const reportResponse = {
           peer_grade: 92,
           instructor_grade: null,
           avg_teammate_score: 73,
+          avg_author_feedback_score: 78,
         },
         "5": {
           participant_id: 202,
           peer_grade: 81,
           instructor_grade: 84,
           avg_teammate_score: 79,
+          avg_author_feedback_score: 75,
         },
       },
     },
@@ -150,6 +153,7 @@ describe("CourseReport", () => {
     expect(screen.getByRole("checkbox", { name: "Peer Grade" })).toBeChecked();
     expect(screen.getByRole("checkbox", { name: "Instructor Grade" })).toBeChecked();
     expect(screen.getByRole("checkbox", { name: "Avg. Teammate Score" })).toBeChecked();
+    expect(screen.getByRole("checkbox", { name: "Avg. Author Feedback Score" })).toBeChecked();
   });
 
   it("passes the class average row to the first table and student rows to the second table", () => {
@@ -188,7 +192,7 @@ describe("CourseReport", () => {
     expect(mockTable.mock.calls[1][0].columnVisibility.a3_topic).toBe(false);
   });
 
-  it("updates peer, instructor, and teammate column visibility when their checkboxes are toggled", async () => {
+  it("updates peer, instructor, teammate, and author feedback column visibility when their checkboxes are toggled", async () => {
     const user = userEvent.setup();
 
     render(<CourseReport />);
@@ -197,6 +201,7 @@ describe("CourseReport", () => {
     await user.click(screen.getByRole("checkbox", { name: "Peer Grade" }));
     await user.click(screen.getByRole("checkbox", { name: "Instructor Grade" }));
     await user.click(screen.getByRole("checkbox", { name: "Avg. Teammate Score" }));
+    await user.click(screen.getByRole("checkbox", { name: "Avg. Author Feedback Score" }));
 
     await waitFor(() => expect(mockTable).toHaveBeenCalled());
     const latestProps = mockTable.mock.calls.at(-1)?.[0];
@@ -204,8 +209,10 @@ describe("CourseReport", () => {
     expect(latestProps.columnVisibility.a3_peerGrade).toBe(false);
     expect(latestProps.columnVisibility.a3_instructorGrade).toBe(false);
     expect(latestProps.columnVisibility.a3_avgTeammateScore).toBe(false);
+    expect(latestProps.columnVisibility.a3_avgAuthorFeedbackScore).toBe(false);
     expect(latestProps.columnVisibility.a5_peerGrade).toBe(false);
     expect(latestProps.columnVisibility.a5_instructorGrade).toBe(false);
     expect(latestProps.columnVisibility.a5_avgTeammateScore).toBe(false);
+    expect(latestProps.columnVisibility.a5_avgAuthorFeedbackScore).toBe(false);
   });
 });

--- a/src/pages/Courses/CourseReport.test.tsx
+++ b/src/pages/Courses/CourseReport.test.tsx
@@ -104,12 +104,12 @@ describe("CourseReport", () => {
     setUseApiState();
   });
 
-  it("requests assignment records for the current course id", async () => {
+  it("requests course reports for the current course id", async () => {
     render(<CourseReport />);
 
     await waitFor(() =>
       expect(mockSendRequest).toHaveBeenCalledWith({
-        url: "/assignment_records?course_id=44",
+        url: "/course_reports?course_id=44",
       })
     );
   });

--- a/src/pages/Courses/CourseReport.tsx
+++ b/src/pages/Courses/CourseReport.tsx
@@ -1,0 +1,149 @@
+import { ChangeEvent, useEffect, useMemo, useState } from "react";
+import { Alert, Col, Container, Form, Row, Spinner } from "react-bootstrap";
+import { useParams } from "react-router-dom";
+import Table from "../../components/Table/Table";
+import useAPI from "../../hooks/useAPI";
+import {
+  buildColumns,
+  buildRows,
+} from "../../services/courseAssignmentOverviewService";
+import {
+  CourseReportApiResponse,
+  DEFAULT_VISIBLE_FIELDS,
+  VisibleFields,
+} from "../../types/courseAssignmentOverview";
+
+const CourseReport = () => {
+  const { courseId } = useParams();
+  const { data, error, isLoading, sendRequest } = useAPI();
+  const [visibleFields, setVisibleFields] =
+    useState<VisibleFields>(DEFAULT_VISIBLE_FIELDS);
+
+  useEffect(() => {
+    if (courseId) {
+      sendRequest({ url: `/assignment_records?course_id=${courseId}` });
+    }
+  }, [courseId, sendRequest]);
+
+  const reportData = data?.data as CourseReportApiResponse | undefined;
+  const assignments = reportData?.assignments ?? [];
+  const students = reportData?.students ?? [];
+
+  const rows = useMemo(() => buildRows(students, assignments), [students, assignments]);
+  const columns = useMemo(
+    () => buildColumns(assignments, visibleFields),
+    [assignments, visibleFields]
+  );
+
+  const columnVisibility = useMemo(
+    () =>
+      assignments.reduce<Record<string, boolean>>(
+        (acc, assignment) => {
+          if (assignment.has_topics) {
+            acc[`a${assignment.assignment_id}_topic`] = visibleFields.topic;
+          }
+          acc[`a${assignment.assignment_id}_peerGrade`] = visibleFields.peerGrade;
+          acc[`a${assignment.assignment_id}_instructorGrade`] =
+            visibleFields.instructorGrade;
+          acc[`a${assignment.assignment_id}_avgTeammateScore`] =
+            visibleFields.avgTeammateScore;
+          return acc;
+        },
+        { studentName: true }
+      ),
+    [assignments, visibleFields]
+  );
+
+  const tableKey = useMemo(
+    () =>
+      JSON.stringify({
+        assignments: assignments.map((assignment) => assignment.assignment_id),
+        visibleFields,
+      }),
+    [assignments, visibleFields]
+  );
+
+  const handleFieldToggle =
+    (field: keyof VisibleFields) => (event: ChangeEvent<HTMLInputElement>) => {
+      setVisibleFields((prev) => ({
+        ...prev,
+        [field]: event.target.checked,
+      }));
+    };
+
+  if (isLoading) {
+    return (
+      <Container className="py-4 text-center">
+        <Spinner animation="border" />
+      </Container>
+    );
+  }
+
+  if (error) {
+    return (
+      <Container className="py-4">
+        <Alert variant="danger">{error}</Alert>
+      </Container>
+    );
+  }
+
+  return (
+    <main>
+      <Container fluid className="px-md-4">
+        <Row className="mt-4 mb-4">
+          <Col className="text-center">
+            <h1 className="text-dark" style={{ fontSize: "2rem", fontWeight: "600" }}>
+              Course Report — {reportData?.course_name}
+            </h1>
+          </Col>
+        </Row>
+        <Row className="mb-3">
+          <Col>
+            <div className="d-flex flex-wrap gap-3">
+              <Form.Check
+                type="checkbox"
+                id="course-report-topic"
+                label="Topic"
+                checked={visibleFields.topic}
+                onChange={handleFieldToggle("topic")}
+              />
+              <Form.Check
+                type="checkbox"
+                id="course-report-peer-grade"
+                label="Peer Grade"
+                checked={visibleFields.peerGrade}
+                onChange={handleFieldToggle("peerGrade")}
+              />
+              <Form.Check
+                type="checkbox"
+                id="course-report-instructor-grade"
+                label="Instructor Grade"
+                checked={visibleFields.instructorGrade}
+                onChange={handleFieldToggle("instructorGrade")}
+              />
+              <Form.Check
+                type="checkbox"
+                id="course-report-avg-teammate-score"
+                label="Avg. Teammate Score"
+                checked={visibleFields.avgTeammateScore}
+                onChange={handleFieldToggle("avgTeammateScore")}
+              />
+            </div>
+          </Col>
+        </Row>
+        <Row>
+          <Table
+            key={tableKey}
+            data={rows}
+            columns={columns}
+            columnVisibility={columnVisibility}
+            showPagination={false}
+            showGlobalFilter={false}
+          />
+        </Row>
+      </Container>
+    </main>
+  );
+};
+
+export default CourseReport;

--- a/src/pages/Courses/CourseReport.tsx
+++ b/src/pages/Courses/CourseReport.tsx
@@ -21,7 +21,7 @@ const CourseReport = () => {
 
   useEffect(() => {
     if (courseId) {
-      sendRequest({ url: `/assignment_records?course_id=${courseId}` });
+      sendRequest({ url: `/course_reports?course_id=${courseId}` });
     }
   }, [courseId, sendRequest]);
 

--- a/src/pages/Courses/CourseReport.tsx
+++ b/src/pages/Courses/CourseReport.tsx
@@ -55,6 +55,8 @@ const CourseReport = () => {
             visibleFields.instructorGrade;
           acc[`a${assignment.assignment_id}_avgTeammateScore`] =
             visibleFields.avgTeammateScore;
+          acc[`a${assignment.assignment_id}_avgAuthorFeedbackScore`] =
+            visibleFields.avgAuthorFeedbackScore;
           return acc;
         },
         { studentName: true }
@@ -135,6 +137,13 @@ const CourseReport = () => {
                 label="Avg. Teammate Score"
                 checked={visibleFields.avgTeammateScore}
                 onChange={handleFieldToggle("avgTeammateScore")}
+              />
+              <Form.Check
+                type="checkbox"
+                id="course-report-avg-author-feedback-score"
+                label="Avg. Author Feedback Score"
+                checked={visibleFields.avgAuthorFeedbackScore}
+                onChange={handleFieldToggle("avgAuthorFeedbackScore")}
               />
             </div>
           </Col>

--- a/src/pages/Courses/CourseReport.tsx
+++ b/src/pages/Courses/CourseReport.tsx
@@ -30,6 +30,14 @@ const CourseReport = () => {
   const students = reportData?.students ?? [];
 
   const rows = useMemo(() => buildRows(students, assignments), [students, assignments]);
+  const classAverageRow = useMemo(
+    () => rows.find((row) => row.isClassAverage),
+    [rows]
+  );
+  const studentRows = useMemo(
+    () => rows.filter((row) => !row.isClassAverage),
+    [rows]
+  );
   const columns = useMemo(
     () => buildColumns(assignments, visibleFields),
     [assignments, visibleFields]
@@ -131,13 +139,28 @@ const CourseReport = () => {
             </div>
           </Col>
         </Row>
+        {classAverageRow && (
+          <Row className="mb-2">
+            <Table
+              key={`${tableKey}-class-average`}
+              data={[classAverageRow]}
+              columns={columns}
+              columnVisibility={columnVisibility}
+              showPagination={false}
+              disablePaginationRowModel
+              showGlobalFilter={false}
+              showColumnFilter={false}
+            />
+          </Row>
+        )}
         <Row>
           <Table
             key={tableKey}
-            data={rows}
+            data={studentRows}
             columns={columns}
             columnVisibility={columnVisibility}
             showPagination={false}
+            disablePaginationRowModel
             showGlobalFilter={false}
           />
         </Row>

--- a/src/services/__tests__/courseAssignmentOverviewService.test.ts
+++ b/src/services/__tests__/courseAssignmentOverviewService.test.ts
@@ -153,32 +153,32 @@ describe("courseAssignmentOverviewService buildRows", () => {
     });
   });
 
-  it("computes the mean peer grade for each assignment using only numeric values", () => {
+  it("computes the mean peer grade for each assignment with null scores counted as zero", () => {
     const classAverageRow = buildRows(students, assignments).at(-1);
 
-    expect(classAverageRow?.a3_peerGrade).toBe(90);
-    expect(classAverageRow?.a5_peerGrade).toBe(60);
+    expect(classAverageRow?.a3_peerGrade).toBe(60);
+    expect(classAverageRow?.a5_peerGrade).toBe(30);
   });
 
-  it("computes the mean instructor grade for each assignment using only numeric values", () => {
+  it("computes the mean instructor grade for each assignment with null scores counted as zero", () => {
     const classAverageRow = buildRows(students, assignments).at(-1);
 
-    expect(classAverageRow?.a3_instructorGrade).toBe(90);
-    expect(classAverageRow?.a5_instructorGrade).toBe(70);
+    expect(classAverageRow?.a3_instructorGrade).toBe(30);
+    expect(classAverageRow?.a5_instructorGrade).toBe(35);
   });
 
-  it("computes the mean teammate score for each assignment using only numeric values", () => {
+  it("computes the mean teammate score for each assignment with null scores counted as zero", () => {
     const classAverageRow = buildRows(students, assignments).at(-1);
 
-    expect(classAverageRow?.a3_avgTeammateScore).toBe(60);
-    expect(classAverageRow?.a5_avgTeammateScore).toBe(80);
+    expect(classAverageRow?.a3_avgTeammateScore).toBe(40);
+    expect(classAverageRow?.a5_avgTeammateScore).toBe(40);
   });
 
-  it("computes the mean author feedback score for each assignment using only numeric values", () => {
+  it("computes the mean author feedback score for each assignment with null scores counted as zero", () => {
     const classAverageRow = buildRows(students, assignments).at(-1);
 
-    expect(classAverageRow?.a3_avgAuthorFeedbackScore).toBe(70);
-    expect(classAverageRow?.a5_avgAuthorFeedbackScore).toBe(90);
+    expect(classAverageRow?.a3_avgAuthorFeedbackScore).toBeCloseTo(46.67);
+    expect(classAverageRow?.a5_avgAuthorFeedbackScore).toBe(45);
   });
 
   it("sets the class average topic field to null for topic-enabled assignments", () => {
@@ -187,7 +187,7 @@ describe("courseAssignmentOverviewService buildRows", () => {
     expect(classAverageRow?.a3_topic).toBeNull();
   });
 
-  it("returns null averages when no student has a numeric value for that field", () => {
+  it("returns zero averages when student scores are null for that field", () => {
     const emptyAverageRows = buildRows(
       [
         {
@@ -209,10 +209,10 @@ describe("courseAssignmentOverviewService buildRows", () => {
 
     const classAverageRow = emptyAverageRows.at(-1);
 
-    expect(classAverageRow?.a3_peerGrade).toBeNull();
-    expect(classAverageRow?.a3_instructorGrade).toBeNull();
-    expect(classAverageRow?.a3_avgTeammateScore).toBeNull();
-    expect(classAverageRow?.a3_avgAuthorFeedbackScore).toBeNull();
+    expect(classAverageRow?.a3_peerGrade).toBe(0);
+    expect(classAverageRow?.a3_instructorGrade).toBe(0);
+    expect(classAverageRow?.a3_avgTeammateScore).toBe(0);
+    expect(classAverageRow?.a3_avgAuthorFeedbackScore).toBe(0);
   });
 
   it("still returns a class average row even when there are no students", () => {

--- a/src/services/__tests__/courseAssignmentOverviewService.test.ts
+++ b/src/services/__tests__/courseAssignmentOverviewService.test.ts
@@ -1,0 +1,290 @@
+import React from "react";
+import {
+  buildColumns,
+  buildRows,
+} from "../courseAssignmentOverviewService";
+import {
+  AssignmentMetadata,
+  StudentReportEntry,
+  VisibleFields,
+} from "../../types/courseAssignmentOverview";
+
+const assignments: AssignmentMetadata[] = [
+  {
+    assignment_id: 3,
+    assignment_name: "Assignment 3",
+    has_topics: true,
+  },
+  {
+    assignment_id: 5,
+    assignment_name: "Assignment 5",
+    has_topics: false,
+  },
+];
+
+const students: StudentReportEntry[] = [
+  {
+    user_id: 1,
+    user_name: "Alice",
+    assignments: {
+      "3": {
+        participant_id: 101,
+        peer_grade: 80,
+        instructor_grade: 90,
+        avg_teammate_score: 70,
+        topic: "Topic Alpha",
+      },
+      "5": null,
+    },
+  },
+  {
+    user_id: 2,
+    user_name: "Bob",
+    assignments: {
+      "3": {
+        participant_id: 102,
+        peer_grade: 100,
+        instructor_grade: null,
+        avg_teammate_score: 50,
+      },
+      "5": {
+        participant_id: 202,
+        peer_grade: 60,
+        instructor_grade: 70,
+        avg_teammate_score: 80,
+      },
+    },
+  },
+  {
+    user_id: 3,
+    user_name: "Cara",
+    assignments: {
+      "3": {
+        participant_id: 103,
+        peer_grade: null,
+        instructor_grade: null,
+        avg_teammate_score: null,
+        topic: "Topic Gamma",
+      },
+      "5": {
+        participant_id: 203,
+        peer_grade: null,
+        instructor_grade: null,
+        avg_teammate_score: null,
+      },
+    },
+  },
+];
+
+const visibleFields: VisibleFields = {
+  topic: false,
+  peerGrade: true,
+  instructorGrade: false,
+  avgTeammateScore: true,
+};
+
+describe("courseAssignmentOverviewService buildRows", () => {
+  it("returns one row per student plus a class average row", () => {
+    const rows = buildRows(students, assignments);
+
+    expect(rows).toHaveLength(4);
+  });
+
+  it("preserves the student name on each student row", () => {
+    const [aliceRow] = buildRows(students, assignments);
+
+    expect(aliceRow.studentName).toBe("Alice");
+  });
+
+  it("creates dynamic numeric field keys for assignment data", () => {
+    const [aliceRow] = buildRows(students, assignments);
+
+    expect(aliceRow.a3_peerGrade).toBe(80);
+    expect(aliceRow.a3_instructorGrade).toBe(90);
+    expect(aliceRow.a3_avgTeammateScore).toBe(70);
+  });
+
+  it("includes a topic key when the assignment has topics", () => {
+    const [aliceRow] = buildRows(students, assignments);
+
+    expect(aliceRow.a3_topic).toBe("Topic Alpha");
+  });
+
+  it("does not create a topic key when the assignment has_topics flag is false", () => {
+    const [, bobRow] = buildRows(students, assignments);
+
+    expect("a5_topic" in bobRow).toBe(false);
+  });
+
+  it("skips an assignment entirely when the student is not a participant", () => {
+    const [aliceRow] = buildRows(students, assignments);
+
+    expect("a5_peerGrade" in aliceRow).toBe(false);
+    expect("a5_instructorGrade" in aliceRow).toBe(false);
+    expect("a5_avgTeammateScore" in aliceRow).toBe(false);
+  });
+
+  it("treats a missing topic on a topic-enabled assignment as null", () => {
+    const [, bobRow] = buildRows(students, assignments);
+
+    expect(bobRow.a3_topic).toBeNull();
+  });
+
+  it("preserves null numeric values on student rows", () => {
+    const [, bobRow] = buildRows(students, assignments);
+
+    expect(bobRow.a3_instructorGrade).toBeNull();
+  });
+
+  it("marks the appended summary row as the class average row", () => {
+    const classAverageRow = buildRows(students, assignments).at(-1);
+
+    expect(classAverageRow).toMatchObject({
+      studentName: "Class Average",
+      isClassAverage: true,
+    });
+  });
+
+  it("computes the mean peer grade for each assignment using only numeric values", () => {
+    const classAverageRow = buildRows(students, assignments).at(-1);
+
+    expect(classAverageRow?.a3_peerGrade).toBe(90);
+    expect(classAverageRow?.a5_peerGrade).toBe(60);
+  });
+
+  it("computes the mean instructor grade for each assignment using only numeric values", () => {
+    const classAverageRow = buildRows(students, assignments).at(-1);
+
+    expect(classAverageRow?.a3_instructorGrade).toBe(90);
+    expect(classAverageRow?.a5_instructorGrade).toBe(70);
+  });
+
+  it("computes the mean teammate score for each assignment using only numeric values", () => {
+    const classAverageRow = buildRows(students, assignments).at(-1);
+
+    expect(classAverageRow?.a3_avgTeammateScore).toBe(60);
+    expect(classAverageRow?.a5_avgTeammateScore).toBe(80);
+  });
+
+  it("sets the class average topic field to null for topic-enabled assignments", () => {
+    const classAverageRow = buildRows(students, assignments).at(-1);
+
+    expect(classAverageRow?.a3_topic).toBeNull();
+  });
+
+  it("returns null averages when no student has a numeric value for that field", () => {
+    const emptyAverageRows = buildRows(
+      [
+        {
+          user_id: 9,
+          user_name: "Only Nulls",
+          assignments: {
+            "3": {
+              participant_id: 909,
+              peer_grade: null,
+              instructor_grade: null,
+              avg_teammate_score: null,
+            },
+          },
+        },
+      ],
+      [{ assignment_id: 3, assignment_name: "A3", has_topics: true }]
+    );
+
+    const classAverageRow = emptyAverageRows.at(-1);
+
+    expect(classAverageRow?.a3_peerGrade).toBeNull();
+    expect(classAverageRow?.a3_instructorGrade).toBeNull();
+    expect(classAverageRow?.a3_avgTeammateScore).toBeNull();
+  });
+
+  it("still returns a class average row even when there are no students", () => {
+    const rows = buildRows([], assignments);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].studentName).toBe("Class Average");
+  });
+});
+
+describe("courseAssignmentOverviewService buildColumns", () => {
+  it("places the student name column first and makes it sortable", () => {
+    const columns = buildColumns(assignments, visibleFields) as any[];
+
+    expect(columns[0].id).toBe("studentName");
+    expect(columns[0].enableSorting).toBe(true);
+  });
+
+  it("creates one assignment group per assignment using the assignment name as the header", () => {
+    const columns = buildColumns(assignments, visibleFields) as any[];
+
+    expect(columns).toHaveLength(3);
+    expect(columns[1].header).toBe("Assignment 3");
+    expect(columns[2].header).toBe("Assignment 5");
+  });
+
+  it("creates the topic sub-column only for assignments that have topics", () => {
+    const columns = buildColumns(assignments, visibleFields) as any[];
+    const assignmentThreeColumns = columns[1].columns;
+    const assignmentFiveColumns = columns[2].columns;
+
+    expect(assignmentThreeColumns.map((column: any) => column.id)).toContain("a3_topic");
+    expect(assignmentFiveColumns.map((column: any) => column.id)).not.toContain("a5_topic");
+  });
+
+  it("creates peer grade columns for every assignment", () => {
+    const columns = buildColumns(assignments, visibleFields) as any[];
+
+    expect(columns[1].columns.map((column: any) => column.id)).toContain("a3_peerGrade");
+    expect(columns[2].columns.map((column: any) => column.id)).toContain("a5_peerGrade");
+  });
+
+  it("creates instructor grade columns for every assignment", () => {
+    const columns = buildColumns(assignments, visibleFields) as any[];
+
+    expect(columns[1].columns.map((column: any) => column.id)).toContain("a3_instructorGrade");
+    expect(columns[2].columns.map((column: any) => column.id)).toContain("a5_instructorGrade");
+  });
+
+  it("creates teammate score columns for every assignment", () => {
+    const columns = buildColumns(assignments, visibleFields) as any[];
+
+    expect(columns[1].columns.map((column: any) => column.id)).toContain("a3_avgTeammateScore");
+    expect(columns[2].columns.map((column: any) => column.id)).toContain("a5_avgTeammateScore");
+  });
+
+  it("marks every generated assignment sub-column as sortable", () => {
+    const columns = buildColumns(assignments, visibleFields) as any[];
+    const assignmentColumns = [...columns[1].columns, ...columns[2].columns];
+
+    expect(assignmentColumns.every((column: any) => column.enableSorting)).toBe(true);
+  });
+
+  it("stores visibility metadata for the generated sub-columns", () => {
+    const columns = buildColumns(assignments, visibleFields) as any[];
+    const assignmentThreeColumns = columns[1].columns;
+
+    expect(
+      assignmentThreeColumns.find((column: any) => column.id === "a3_topic").meta
+    ).toEqual({ requestedVisible: false });
+    expect(
+      assignmentThreeColumns.find((column: any) => column.id === "a3_peerGrade").meta
+    ).toEqual({ requestedVisible: true });
+    expect(
+      assignmentThreeColumns.find((column: any) => column.id === "a3_instructorGrade").meta
+    ).toEqual({ requestedVisible: false });
+    expect(
+      assignmentThreeColumns.find((column: any) => column.id === "a3_avgTeammateScore").meta
+    ).toEqual({ requestedVisible: true });
+  });
+
+  it("renders class average cells in bold through the generated cell renderer", () => {
+    const columns = buildColumns(assignments, visibleFields) as any[];
+    const studentNameCell = columns[0].cell({
+      row: { original: { studentName: "Class Average", isClassAverage: true } },
+      getValue: () => "Class Average",
+    });
+
+    expect(React.isValidElement(studentNameCell)).toBe(true);
+    expect((studentNameCell as React.ReactElement).props.className).toBe("fw-bold");
+  });
+});

--- a/src/services/__tests__/courseAssignmentOverviewService.test.ts
+++ b/src/services/__tests__/courseAssignmentOverviewService.test.ts
@@ -32,6 +32,7 @@ const students: StudentReportEntry[] = [
         peer_grade: 80,
         instructor_grade: 90,
         avg_teammate_score: 70,
+        avg_author_feedback_score: 65,
         topic: "Topic Alpha",
       },
       "5": null,
@@ -46,12 +47,14 @@ const students: StudentReportEntry[] = [
         peer_grade: 100,
         instructor_grade: null,
         avg_teammate_score: 50,
+        avg_author_feedback_score: 75,
       },
       "5": {
         participant_id: 202,
         peer_grade: 60,
         instructor_grade: 70,
         avg_teammate_score: 80,
+        avg_author_feedback_score: 90,
       },
     },
   },
@@ -64,6 +67,7 @@ const students: StudentReportEntry[] = [
         peer_grade: null,
         instructor_grade: null,
         avg_teammate_score: null,
+        avg_author_feedback_score: null,
         topic: "Topic Gamma",
       },
       "5": {
@@ -71,6 +75,7 @@ const students: StudentReportEntry[] = [
         peer_grade: null,
         instructor_grade: null,
         avg_teammate_score: null,
+        avg_author_feedback_score: null,
       },
     },
   },
@@ -81,6 +86,7 @@ const visibleFields: VisibleFields = {
   peerGrade: true,
   instructorGrade: false,
   avgTeammateScore: true,
+  avgAuthorFeedbackScore: true,
 };
 
 describe("courseAssignmentOverviewService buildRows", () => {
@@ -102,6 +108,7 @@ describe("courseAssignmentOverviewService buildRows", () => {
     expect(aliceRow.a3_peerGrade).toBe(80);
     expect(aliceRow.a3_instructorGrade).toBe(90);
     expect(aliceRow.a3_avgTeammateScore).toBe(70);
+    expect(aliceRow.a3_avgAuthorFeedbackScore).toBe(65);
   });
 
   it("includes a topic key when the assignment has topics", () => {
@@ -122,6 +129,7 @@ describe("courseAssignmentOverviewService buildRows", () => {
     expect("a5_peerGrade" in aliceRow).toBe(false);
     expect("a5_instructorGrade" in aliceRow).toBe(false);
     expect("a5_avgTeammateScore" in aliceRow).toBe(false);
+    expect("a5_avgAuthorFeedbackScore" in aliceRow).toBe(false);
   });
 
   it("treats a missing topic on a topic-enabled assignment as null", () => {
@@ -166,6 +174,13 @@ describe("courseAssignmentOverviewService buildRows", () => {
     expect(classAverageRow?.a5_avgTeammateScore).toBe(80);
   });
 
+  it("computes the mean author feedback score for each assignment using only numeric values", () => {
+    const classAverageRow = buildRows(students, assignments).at(-1);
+
+    expect(classAverageRow?.a3_avgAuthorFeedbackScore).toBe(70);
+    expect(classAverageRow?.a5_avgAuthorFeedbackScore).toBe(90);
+  });
+
   it("sets the class average topic field to null for topic-enabled assignments", () => {
     const classAverageRow = buildRows(students, assignments).at(-1);
 
@@ -184,6 +199,7 @@ describe("courseAssignmentOverviewService buildRows", () => {
               peer_grade: null,
               instructor_grade: null,
               avg_teammate_score: null,
+              avg_author_feedback_score: null,
             },
           },
         },
@@ -196,6 +212,7 @@ describe("courseAssignmentOverviewService buildRows", () => {
     expect(classAverageRow?.a3_peerGrade).toBeNull();
     expect(classAverageRow?.a3_instructorGrade).toBeNull();
     expect(classAverageRow?.a3_avgTeammateScore).toBeNull();
+    expect(classAverageRow?.a3_avgAuthorFeedbackScore).toBeNull();
   });
 
   it("still returns a class average row even when there are no students", () => {
@@ -252,6 +269,13 @@ describe("courseAssignmentOverviewService buildColumns", () => {
     expect(columns[2].columns.map((column: any) => column.id)).toContain("a5_avgTeammateScore");
   });
 
+  it("creates author feedback score columns for every assignment", () => {
+    const columns = buildColumns(assignments, visibleFields) as any[];
+
+    expect(columns[1].columns.map((column: any) => column.id)).toContain("a3_avgAuthorFeedbackScore");
+    expect(columns[2].columns.map((column: any) => column.id)).toContain("a5_avgAuthorFeedbackScore");
+  });
+
   it("marks every generated assignment sub-column as sortable", () => {
     const columns = buildColumns(assignments, visibleFields) as any[];
     const assignmentColumns = [...columns[1].columns, ...columns[2].columns];
@@ -274,6 +298,9 @@ describe("courseAssignmentOverviewService buildColumns", () => {
     ).toEqual({ requestedVisible: false });
     expect(
       assignmentThreeColumns.find((column: any) => column.id === "a3_avgTeammateScore").meta
+    ).toEqual({ requestedVisible: true });
+    expect(
+      assignmentThreeColumns.find((column: any) => column.id === "a3_avgAuthorFeedbackScore").meta
     ).toEqual({ requestedVisible: true });
   });
 

--- a/src/services/courseAssignmentOverviewService.ts
+++ b/src/services/courseAssignmentOverviewService.ts
@@ -1,0 +1,155 @@
+import React from "react";
+import { createColumnHelper } from "@tanstack/react-table";
+import {
+  AssignmentMetadata,
+  StudentReportEntry,
+  VisibleFields,
+} from "../types/courseAssignmentOverview";
+
+type CourseReportRow = {
+  studentId?: number;
+  studentName: string;
+  isClassAverage?: boolean;
+  [key: string]: number | string | boolean | null | undefined;
+};
+
+const columnHelper = createColumnHelper<CourseReportRow>();
+
+const renderCellValue = (
+  value: number | string | boolean | null | undefined,
+  isClassAverage: boolean | undefined
+) =>
+  React.createElement(
+    "span",
+    { className: isClassAverage ? "fw-bold" : undefined },
+    value === null || value === undefined ? "" : String(value)
+  );
+
+export const buildRows = (
+  students: StudentReportEntry[],
+  assignments: AssignmentMetadata[]
+): CourseReportRow[] => {
+  const numericFields = [
+    { suffix: "peerGrade", key: "peer_grade" as const },
+    { suffix: "instructorGrade", key: "instructor_grade" as const },
+    { suffix: "avgTeammateScore", key: "avg_teammate_score" as const },
+  ];
+
+  const averages = assignments.reduce<Record<string, { sum: number; count: number }>>(
+    (acc, assignment) => {
+      numericFields.forEach(({ suffix }) => {
+        acc[`a${assignment.assignment_id}_${suffix}`] = { sum: 0, count: 0 };
+      });
+      return acc;
+    },
+    {}
+  );
+
+  const rows = students.map((student) => {
+    const row: CourseReportRow = {
+      studentId: student.user_id,
+      studentName: student.user_name,
+    };
+
+    assignments.forEach((assignment) => {
+      const assignmentData = student.assignments[String(assignment.assignment_id)];
+
+      if (!assignmentData) {
+        return;
+      }
+
+      if (assignment.has_topics) {
+        row[`a${assignment.assignment_id}_topic`] = assignmentData.topic ?? null;
+      }
+
+      numericFields.forEach(({ suffix, key }) => {
+        const columnKey = `a${assignment.assignment_id}_${suffix}`;
+        const value = assignmentData[key];
+
+        row[columnKey] = value;
+
+        if (typeof value === "number") {
+          averages[columnKey].sum += value;
+          averages[columnKey].count += 1;
+        }
+      });
+    });
+
+    return row;
+  });
+
+  const classAverageRow: CourseReportRow = {
+    studentName: "Class Average",
+    isClassAverage: true,
+  };
+
+  assignments.forEach((assignment) => {
+    if (assignment.has_topics) {
+      classAverageRow[`a${assignment.assignment_id}_topic`] = null;
+    }
+
+    numericFields.forEach(({ suffix }) => {
+      const columnKey = `a${assignment.assignment_id}_${suffix}`;
+      const { sum, count } = averages[columnKey];
+      classAverageRow[columnKey] = count > 0 ? sum / count : null;
+    });
+  });
+
+  return [...rows, classAverageRow];
+};
+
+export const buildColumns = (
+  assignments: AssignmentMetadata[],
+  visibleFields: VisibleFields
+) => [
+  columnHelper.accessor("studentName", {
+    id: "studentName",
+    header: "Student Name",
+    cell: ({ row, getValue }) => renderCellValue(getValue(), row.original.isClassAverage),
+    enableSorting: true,
+  }),
+  ...assignments.map((assignment) =>
+    columnHelper.group({
+      id: `assignment_${assignment.assignment_id}`,
+      header: assignment.assignment_name,
+      columns: [
+        ...(assignment.has_topics
+          ? [
+              columnHelper.accessor(`a${assignment.assignment_id}_topic`, {
+                id: `a${assignment.assignment_id}_topic`,
+                header: "Topic",
+                cell: ({ row, getValue }) =>
+                  renderCellValue(getValue(), row.original.isClassAverage),
+                enableSorting: true,
+                meta: { requestedVisible: visibleFields.topic },
+              }),
+            ]
+          : []),
+        columnHelper.accessor(`a${assignment.assignment_id}_peerGrade`, {
+          id: `a${assignment.assignment_id}_peerGrade`,
+          header: "Peer Grade",
+          cell: ({ row, getValue }) =>
+            renderCellValue(getValue(), row.original.isClassAverage),
+          enableSorting: true,
+          meta: { requestedVisible: visibleFields.peerGrade },
+        }),
+        columnHelper.accessor(`a${assignment.assignment_id}_instructorGrade`, {
+          id: `a${assignment.assignment_id}_instructorGrade`,
+          header: "Instructor Grade",
+          cell: ({ row, getValue }) =>
+            renderCellValue(getValue(), row.original.isClassAverage),
+          enableSorting: true,
+          meta: { requestedVisible: visibleFields.instructorGrade },
+        }),
+        columnHelper.accessor(`a${assignment.assignment_id}_avgTeammateScore`, {
+          id: `a${assignment.assignment_id}_avgTeammateScore`,
+          header: "Avg. Teammate Score",
+          cell: ({ row, getValue }) =>
+            renderCellValue(getValue(), row.original.isClassAverage),
+          enableSorting: true,
+          meta: { requestedVisible: visibleFields.avgTeammateScore },
+        }),
+      ],
+    })
+  ),
+];

--- a/src/services/courseAssignmentOverviewService.ts
+++ b/src/services/courseAssignmentOverviewService.ts
@@ -72,6 +72,8 @@ export const buildRows = (
         if (typeof value === "number") {
           averages[columnKey].sum += value;
           averages[columnKey].count += 1;
+        } else if (value === null) {
+          averages[columnKey].count += 1;
         }
       });
     });

--- a/src/services/courseAssignmentOverviewService.ts
+++ b/src/services/courseAssignmentOverviewService.ts
@@ -33,6 +33,7 @@ export const buildRows = (
     { suffix: "peerGrade", key: "peer_grade" as const },
     { suffix: "instructorGrade", key: "instructor_grade" as const },
     { suffix: "avgTeammateScore", key: "avg_teammate_score" as const },
+    { suffix: "avgAuthorFeedbackScore", key: "avg_author_feedback_score" as const },
   ];
 
   const averages = assignments.reduce<Record<string, { sum: number; count: number }>>(
@@ -148,6 +149,14 @@ export const buildColumns = (
             renderCellValue(getValue(), row.original.isClassAverage),
           enableSorting: true,
           meta: { requestedVisible: visibleFields.avgTeammateScore },
+        }),
+        columnHelper.accessor(`a${assignment.assignment_id}_avgAuthorFeedbackScore`, {
+          id: `a${assignment.assignment_id}_avgAuthorFeedbackScore`,
+          header: "Avg. Author Feedback Score",
+          cell: ({ row, getValue }) =>
+            renderCellValue(getValue(), row.original.isClassAverage),
+          enableSorting: true,
+          meta: { requestedVisible: visibleFields.avgAuthorFeedbackScore },
         }),
       ],
     })

--- a/src/services/courseAssignmentOverviewService.ts
+++ b/src/services/courseAssignmentOverviewService.ts
@@ -32,7 +32,11 @@ const renderCellValue = (
   React.createElement(
     "span",
     { className: isClassAverage ? "fw-bold" : undefined },
-    value === null || value === undefined ? "" : String(value)
+    value === null || value === undefined
+      ? ""
+      : typeof value === "number"
+        ? value.toFixed(2)
+        : String(value)
   );
 
 /*

--- a/src/services/courseAssignmentOverviewService.ts
+++ b/src/services/courseAssignmentOverviewService.ts
@@ -1,3 +1,9 @@
+/*
+ * Transforms the raw course report API response into the rows and column
+ * definitions consumed by Table.tsx. Keeping this logic outside the React
+ * component makes it independently testable.
+ */
+
 import React from "react";
 import { createColumnHelper } from "@tanstack/react-table";
 import {
@@ -15,6 +21,10 @@ type CourseReportRow = {
 
 const columnHelper = createColumnHelper<CourseReportRow>();
 
+/*
+ * Shared cell renderer used by every column. Class average cells render in
+ * bold, while null values render as empty strings rather than "null".
+ */
 const renderCellValue = (
   value: number | string | boolean | null | undefined,
   isClassAverage: boolean | undefined
@@ -25,10 +35,18 @@ const renderCellValue = (
     value === null || value === undefined ? "" : String(value)
   );
 
+/*
+ * Builds flat table rows from students and assignment metadata. Dynamic flat
+ * keys like a{assignmentId}_peerGrade are used because TanStack Table requires
+ * flat accessor keys; null assignment entries for non-participants are skipped.
+ * Null numeric values are preserved on student rows but counted as zero for
+ * class average calculations, and the class average row is always appended last.
+ */
 export const buildRows = (
   students: StudentReportEntry[],
   assignments: AssignmentMetadata[]
 ): CourseReportRow[] => {
+  // Drives both row key generation and running sum accumulation for class averages.
   const numericFields = [
     { suffix: "peerGrade", key: "peer_grade" as const },
     { suffix: "instructorGrade", key: "instructor_grade" as const },
@@ -101,6 +119,13 @@ export const buildRows = (
   return [...rows, classAverageRow];
 };
 
+/*
+ * Builds TanStack column definitions from assignment metadata and checkbox
+ * visibility state. The column exclusion rule is enforced here, not at render
+ * time: the topic sub-column is only created when has_topics is true regardless
+ * of the topic checkbox state. All other sub-columns are always created and
+ * controlled only by columnVisibility in the page component.
+ */
 export const buildColumns = (
   assignments: AssignmentMetadata[],
   visibleFields: VisibleFields

--- a/src/types/courseAssignmentOverview.ts
+++ b/src/types/courseAssignmentOverview.ts
@@ -1,0 +1,40 @@
+export interface AssignmentMetadata {
+  assignment_id: number;
+  assignment_name: string;
+  has_topics: boolean;
+}
+
+export interface AssignmentFieldData {
+  participant_id: number;
+  peer_grade: number | null;
+  instructor_grade: number | null;
+  avg_teammate_score: number | null;
+  topic?: string;
+}
+
+export interface StudentReportEntry {
+  user_id: number;
+  user_name: string;
+  assignments: { [assignmentId: string]: AssignmentFieldData | null };
+}
+
+export interface CourseReportApiResponse {
+  course_id: number;
+  course_name: string;
+  assignments: AssignmentMetadata[];
+  students: StudentReportEntry[];
+}
+
+export type VisibleFields = {
+  topic: boolean;
+  peerGrade: boolean;
+  instructorGrade: boolean;
+  avgTeammateScore: boolean;
+};
+
+export const DEFAULT_VISIBLE_FIELDS: VisibleFields = {
+  topic: true,
+  peerGrade: true,
+  instructorGrade: true,
+  avgTeammateScore: true,
+};

--- a/src/types/courseAssignmentOverview.ts
+++ b/src/types/courseAssignmentOverview.ts
@@ -9,6 +9,7 @@ export interface AssignmentFieldData {
   peer_grade: number | null;
   instructor_grade: number | null;
   avg_teammate_score: number | null;
+  avg_author_feedback_score: number | null;
   topic?: string;
 }
 
@@ -30,6 +31,7 @@ export type VisibleFields = {
   peerGrade: boolean;
   instructorGrade: boolean;
   avgTeammateScore: boolean;
+  avgAuthorFeedbackScore: boolean;
 };
 
 export const DEFAULT_VISIBLE_FIELDS: VisibleFields = {
@@ -37,4 +39,5 @@ export const DEFAULT_VISIBLE_FIELDS: VisibleFields = {
   peerGrade: true,
   instructorGrade: true,
   avgTeammateScore: true,
+  avgAuthorFeedbackScore: true,
 };

--- a/src/types/courseAssignmentOverview.ts
+++ b/src/types/courseAssignmentOverview.ts
@@ -1,9 +1,16 @@
+/*
+ * Shared type contract for the course report feature, covering the API response
+ * shape, the frontend row model, and the checkbox visibility state.
+ */
+
+// Per-assignment structural info returned by the backend, including has_topics for the column exclusion rule.
 export interface AssignmentMetadata {
   assignment_id: number;
   assignment_name: string;
   has_topics: boolean;
 }
 
+// One student's data for one assignment, sourced from Teams, review response maps, and teammate review maps.
 export interface AssignmentFieldData {
   participant_id: number;
   peer_grade: number | null;
@@ -13,12 +20,14 @@ export interface AssignmentFieldData {
   topic?: string;
 }
 
+// One student's full report data, with assignments keyed by assignment ID as a string; null means no participation.
 export interface StudentReportEntry {
   user_id: number;
   user_name: string;
   assignments: { [assignmentId: string]: AssignmentFieldData | null };
 }
 
+// Full response shape returned by GET /course_reports.
 export interface CourseReportApiResponse {
   course_id: number;
   course_name: string;
@@ -26,6 +35,7 @@ export interface CourseReportApiResponse {
   students: StudentReportEntry[];
 }
 
+// Mirrors the checkbox toolbar state, with one boolean per field type.
 export type VisibleFields = {
   topic: boolean;
   peerGrade: boolean;
@@ -34,6 +44,7 @@ export type VisibleFields = {
   avgAuthorFeedbackScore: boolean;
 };
 
+// Initial checkbox state when the report first loads.
 export const DEFAULT_VISIBLE_FIELDS: VisibleFields = {
   topic: true,
   peerGrade: true,


### PR DESCRIPTION
This PR implements the frontend part of the topic E2612 (course reports) for the CSC517 Final Project. We have started with an empty initial commit to signify the start of this PR commit history. This will be bookended by an empty commit signifying the end of this specific feature's commit history once this feature is ready.

This PR contains the changes to the frontend to receive the data from the newly created backend controller and display it in a course-report page in a table based format. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "View Course Report" button opens a per-course report showing class averages and individual student performance; access limited to TA-level users.

* **Reports**
  * Reports show separate class-average and student tables, with checkbox controls to toggle topic/peer/instructor/teammate/feedback columns and stable numeric formatting.

* **Table**
  * Tables can opt out of internal pagination behavior (pagination UI still controllable).

* **Tests**
  * Added extensive tests covering report UI, routing/access, table behavior, and data shaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->