### PR TITLE
E2609: Calibration tab UI & comparison report

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import RootLayout from "./layout/Root";
 import ManageUserTypes, { loader as loadUsers } from "./pages/Administrator/ManageUserTypes";
 import Assignment from "./pages/Assignments/Assignment";
 import AssignmentEditor from "./pages/Assignments/AssignmentEditor";
+import CalibrationReview from "./pages/Assignments/CalibrationReview";
 import { loadAssignment } from "./pages/Assignments/AssignmentUtil";
 import ResponseMappings from "./pages/ResponseMappings/ResponseMappings";
 import CreateTeams from "./pages/Assignments/CreateTeams";
@@ -123,6 +124,10 @@ function App() {
           path: "assignments/edit/:id/viewdelayedjobs",
           element: <ViewDelayedJobs />,
           loader: loadAssignment,
+        },
+        {
+          path: "assignments/edit/:assignmentId/calibration/:mapId",
+          element: <CalibrationReview />,
         },
 
         {

--- a/src/pages/Assignments/AssignmentEditor.tsx
+++ b/src/pages/Assignments/AssignmentEditor.tsx
@@ -111,8 +111,13 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
   const { data: assignmentResponse, error: assignmentError, sendRequest } = useAPI();
   const { data: coursesResponse, error: coursesError, sendRequest: sendCoursesRequest } = useAPI();
   const { data: calibrationSubmissionsResponse, error: calibrationSubmissionsError, sendRequest: sendCalibrationSubmissionsRequest } = useAPI();
+  // Separate hook instances keep add/remove errors from overwriting list errors
+  // and let us trigger reloads only after a mutation succeeds.
+  const { data: addCalibrationResponse, error: addCalibrationError, sendRequest: sendAddCalibrationRequest } = useAPI();
+  const { data: removeCalibrationResponse, error: removeCalibrationError, sendRequest: sendRemoveCalibrationRequest } = useAPI();
   const [courses, setCourses] = useState<any[]>([]);
   const [calibrationSubmissions, setCalibrationSubmissions] = useState<any[]>([]);
+  const [calibrationUsername, setCalibrationUsername] = useState<string>("");
 
   const { data: topicsResponse, error: topicsApiError, sendRequest: fetchTopics } = useAPI();
   const { data: updateResponse, error: updateError, sendRequest: updateAssignment } = useAPI();
@@ -536,32 +541,42 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
     coursesError && dispatch(alertActions.showAlert({ variant: "danger", message: coursesError }));
   }, [coursesError, dispatch]);
 
-  // Load calibration submissions on component mount
-  useEffect(() => {
-    // sendCalibrationSubmissionsRequest({
-    //   url: `/calibration_submissions/get_instructor_calibration_submissions/${assignmentData.id}`,
-    //   method: HttpMethod.GET,
-    // });
-    setCalibrationSubmissions([
-      {
-        id: 1,
-        participant_name: "Participant 1",
-        review_status: "not_started",
-        submitted_content: { hyperlinks: ["https://www.google.com"], files: ["file1.txt", "file2.pdf"] },
-      },
-      {
-        id: 2,
-        participant_name: "Participant 2",
-        review_status: "in_progress",
-        submitted_content: { hyperlinks: ["https://www.google.com"], files: ["file1.txt", "file2.pdf"] },
-      },
-    ]);
-  }, []);
+  // Fetch the calibration submitters for this assignment from the backend.
+  // Wrapped in useCallback so both the initial load and post-mutation
+  // refreshes call the exact same request.
+  const refreshCalibrationParticipants = useCallback(() => {
+    if (!assignmentData?.id) return;
+    sendCalibrationSubmissionsRequest({
+      url: `/assignments/${assignmentData.id}/review_mappings/calibration_participants`,
+      method: HttpMethod.GET,
+    });
+  }, [assignmentData?.id, sendCalibrationSubmissionsRequest]);
 
-  // Handle calibration submissions response
+  // Load calibration submitters on mount / when the assignment id resolves.
   useEffect(() => {
-    if (calibrationSubmissionsResponse && calibrationSubmissionsResponse.status >= 200 && calibrationSubmissionsResponse.status < 300) {
-      setCalibrationSubmissions(calibrationSubmissionsResponse.data || []);
+    refreshCalibrationParticipants();
+  }, [refreshCalibrationParticipants]);
+
+  // Handle calibration submissions response. Backend returns
+  // { assignment_id, calibration_participants: [...] }, which we normalize
+  // into the shape the table expects.
+  useEffect(() => {
+    if (
+      calibrationSubmissionsResponse &&
+      calibrationSubmissionsResponse.status >= 200 &&
+      calibrationSubmissionsResponse.status < 300
+    ) {
+      const body: any = calibrationSubmissionsResponse.data || {};
+      const rows: any[] = Array.isArray(body)
+        ? body
+        : (body.calibration_participants || []);
+      setCalibrationSubmissions(
+        rows.map((row: any) => ({
+          participant_id: row.participant_id,
+          participant_name: row.full_name || row.username || row.handle || `Participant ${row.participant_id}`,
+          submitted_content: row.submissions || { hyperlinks: [], files: [] },
+        }))
+      );
     }
   }, [calibrationSubmissionsResponse]);
 
@@ -569,6 +584,60 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
   useEffect(() => {
     calibrationSubmissionsError && dispatch(alertActions.showAlert({ variant: "danger", message: calibrationSubmissionsError }));
   }, [calibrationSubmissionsError, dispatch]);
+
+  // Success/error handling for adding a calibration participant. Refresh the
+  // list after a successful add so the new row shows up with its submissions.
+  useEffect(() => {
+    if (addCalibrationResponse && addCalibrationResponse.status >= 200 && addCalibrationResponse.status < 300) {
+      dispatch(alertActions.showAlert({ variant: "success", message: "Calibration participant added" }));
+      setCalibrationUsername("");
+      refreshCalibrationParticipants();
+    }
+  }, [addCalibrationResponse, dispatch, refreshCalibrationParticipants]);
+
+  useEffect(() => {
+    addCalibrationError && dispatch(alertActions.showAlert({ variant: "danger", message: addCalibrationError }));
+  }, [addCalibrationError, dispatch]);
+
+  // Success/error handling for removing a calibration participant.
+  useEffect(() => {
+    if (removeCalibrationResponse && removeCalibrationResponse.status >= 200 && removeCalibrationResponse.status < 300) {
+      dispatch(alertActions.showAlert({ variant: "success", message: "Calibration participant removed" }));
+      refreshCalibrationParticipants();
+    }
+  }, [removeCalibrationResponse, dispatch, refreshCalibrationParticipants]);
+
+  useEffect(() => {
+    removeCalibrationError && dispatch(alertActions.showAlert({ variant: "danger", message: removeCalibrationError }));
+  }, [removeCalibrationError, dispatch]);
+
+  const handleAddCalibrationParticipant = useCallback(() => {
+    const username = calibrationUsername.trim();
+    if (!username || !assignmentData?.id) {
+      dispatch(alertActions.showAlert({ variant: "danger", message: "Enter a username to add as a calibration participant." }));
+      return;
+    }
+    sendAddCalibrationRequest({
+      url: `/assignments/${assignmentData.id}/review_mappings/calibration_participants`,
+      method: HttpMethod.POST,
+      data: { username },
+    }).catch(() => {
+      // useAPI already surfaces the error into addCalibrationError.
+    });
+  }, [assignmentData?.id, calibrationUsername, dispatch, sendAddCalibrationRequest]);
+
+  const handleRemoveCalibrationParticipant = useCallback(
+    (participantId: number | string) => {
+      if (!assignmentData?.id || !participantId) return;
+      sendRemoveCalibrationRequest({
+        url: `/assignments/${assignmentData.id}/review_mappings/calibration_participants/${participantId}`,
+        method: HttpMethod.DELETE,
+      }).catch(() => {
+        // useAPI already surfaces the error into removeCalibrationError.
+      });
+    },
+    [assignmentData?.id, sendRemoveCalibrationRequest]
+  );
 
 
   const onSubmit = (
@@ -1168,59 +1237,95 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
 
               {/* Calibration Tab */}
                 <Tab eventKey="calibration" title="Calibration">
-                  <h3>Submit reviews for calibration</h3>
+                  <h3>Calibration submitters</h3>
+                  <p className="text-muted" style={{ maxWidth: 720 }}>
+                    Designate one or more users whose submissions will be used for calibration reviews.
+                    Enter a username or email below. A team is created for the submitter and an
+                    instructor calibration review map is opened automatically.
+                  </p>
+
+                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '1rem', marginBottom: '1.5rem', maxWidth: 520 }}>
+                    <input
+                      type="text"
+                      className="form-control"
+                      placeholder="Username or email"
+                      value={calibrationUsername}
+                      onChange={(e) => setCalibrationUsername(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter') {
+                          e.preventDefault();
+                          handleAddCalibrationParticipant();
+                        }
+                      }}
+                      aria-label="Calibration participant username"
+                    />
+                    <Button
+                      variant="primary"
+                      onClick={handleAddCalibrationParticipant}
+                      disabled={!calibrationUsername.trim()}
+                    >
+                      Add
+                    </Button>
+                  </div>
+
                   <div>
                     <div style={{ display: 'ruby', marginTop: '30px' }}>
                       <Table
                         showColumnFilter={false}
                         showGlobalFilter={false}
                         showPagination={false}
-                        data={[
-                          ...calibrationSubmissions.map((calibrationSubmission: any) => ({
-                            id: calibrationSubmission.id,
-                            participant_name: calibrationSubmission.participant_name,
-                            review_status: calibrationSubmission.review_status,
-                            submitted_content: calibrationSubmission.submitted_content,
-                          })),
-                        ]}
+                        data={calibrationSubmissions.map((calibrationSubmission: any) => ({
+                          participant_id: calibrationSubmission.participant_id,
+                          participant_name: calibrationSubmission.participant_name,
+                          submitted_content: calibrationSubmission.submitted_content,
+                        }))}
                         columns={[
                           {
                             accessorKey: "participant_name", header: "Participant name", enableSorting: false, enableColumnFilter: false
                           },
                           {
-                            cell: ({ row }) => {
-                              if (row.original.review_status === "not_started") {
-                                return <a style={{ color: '#986633', textDecoration: 'none' }} href={`/assignments/edit/${assignmentData.id}/calibration/${row.original.id}`}>Begin</a>;
-                              } else {
-                                return <div style={{ display: 'flex', alignItems: 'center', columnGap: '5px' }}>
-                                  <a style={{ color: '#986633', textDecoration: 'none' }} href={`/assignments/edit/${assignmentData.id}/calibration/${row.original.id}`}>View</a>
-                                  |
-                                  <a style={{ color: '#986633', textDecoration: 'none' }} href={`/assignments/edit/${assignmentData.id}/calibration/${row.original.id}`}>Edit</a>
-                                </div>;
-                              }
-                            },
-                            accessorKey: "action", header: "Action", enableSorting: false, enableColumnFilter: false
+                            cell: ({ row }) => (
+                              <>
+                                <div>Hyperlinks:</div>
+                                <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+                                  {(row.original.submitted_content?.hyperlinks || []).map((item: any, index: number) => (
+                                    <a style={{ color: '#986633', textDecoration: 'none' }} key={`hl-${index}`} href={item}>{item}</a>
+                                  ))}
+                                </div>
+                                <div style={{ marginTop: '10px', display: 'flex', flexDirection: 'column' }}>Files:</div>
+                                <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
+                                  {(row.original.submitted_content?.files || []).map((item: any, index: number) => {
+                                    // Files may arrive as bare strings (report shape) or as
+                                    // { id, name, path, submitted_at, submitted_by } objects
+                                    // (participant-list shape). Handle both.
+                                    const href = typeof item === 'string' ? item : item.path;
+                                    const label = typeof item === 'string' ? item : (item.name || item.path);
+                                    return (
+                                      <a
+                                        style={{ color: '#986633', textDecoration: 'none' }}
+                                        key={`file-${index}`}
+                                        href={href}
+                                      >
+                                        {label}
+                                      </a>
+                                    );
+                                  })}
+                                </div>
+                              </>
+                            ),
+                            accessorKey: "submitted_content", header: "Submitted items(s)", enableSorting: false, enableColumnFilter: false
                           },
                           {
-                            cell: ({ row }) => <>
-                              <div>Hyperlinks:</div>
-                              <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
-                                {
-                                  row.original.submitted_content.hyperlinks.map((item: any, index: number) => {
-                                    return <a style={{ color: '#986633', textDecoration: 'none' }} key={index} href={item}>{item}</a>;
-                                  })
-                                }
-                              </div>
-                              <div style={{ marginTop: '10px', display: 'flex', flexDirection: 'column' }}>Files:</div>
-                              <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
-                                {
-                                  row.original.submitted_content.files.map((item: any, index: number) => {
-                                    return <a style={{ color: '#986633', textDecoration: 'none' }} key={index} href={item}>{item}</a>;
-                                  })
-                                }
-                              </div>
-                            </>,
-                            accessorKey: "submitted_content", header: "Submitted items(s)", enableSorting: false, enableColumnFilter: false
+                            cell: ({ row }) => (
+                              <Button
+                                variant="outline-danger"
+                                size="sm"
+                                onClick={() => handleRemoveCalibrationParticipant(row.original.participant_id)}
+                              >
+                                Remove
+                              </Button>
+                            ),
+                            accessorKey: "remove", header: "", enableSorting: false, enableColumnFilter: false
                           },
                         ]}
                       />

--- a/src/pages/Assignments/AssignmentEditor.tsx
+++ b/src/pages/Assignments/AssignmentEditor.tsx
@@ -24,6 +24,8 @@ import ToolTip from "../../components/ToolTip";
 import EtcTab from './tabs/EtcTab';
 import TopicsTab from "./tabs/TopicsTab";
 import DutyEditor from "pages/Duties/DutyEditor";
+// DEMO_INSTRUCTOR_RESPONSE: remove this import when the real review form ships.
+import useCalibrationInstructorDemo from "./hooks/useCalibrationInstructorDemo";
 
 interface TopicSettings {
   allowTopicSuggestions: boolean;
@@ -115,15 +117,6 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
   // and let us trigger reloads only after a mutation succeeds.
   const { data: addCalibrationResponse, error: addCalibrationError, sendRequest: sendAddCalibrationRequest } = useAPI();
   const { data: removeCalibrationResponse, error: removeCalibrationError, sendRequest: sendRemoveCalibrationRequest } = useAPI();
-  // DEMO_INSTRUCTOR_RESPONSE
-  // Demo-only: "Begin" on the Calibration tab seeds a mock instructor
-  // calibration response so the report has data to render. The real review
-  // form is out of scope of this project. When the real form ships, delete
-  // this hook, the handleBeginCalibrationReview callback, both useEffects
-  // that consume beginCalibrationResponse / beginCalibrationError, and
-  // switch the "Begin" button in the Review-column cell back to a plain
-  // anchor pointing at the real review URL.
-  const { data: beginCalibrationResponse, error: beginCalibrationError, sendRequest: sendBeginCalibrationRequest } = useAPI();
   const [courses, setCourses] = useState<any[]>([]);
   const [calibrationSubmissions, setCalibrationSubmissions] = useState<any[]>([]);
   const [calibrationUsername, setCalibrationUsername] = useState<string>("");
@@ -653,37 +646,13 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
     [assignmentData?.id, sendRemoveCalibrationRequest]
   );
 
-  // DEMO_INSTRUCTOR_RESPONSE
-  // Demo-only: kick off a mock instructor calibration response when the
-  // instructor clicks "Begin" on a calibration row. The backend materializes
-  // a submitted Response with default answers so the calibration report has
-  // data to display. Once it returns, refresh the participant list so the
-  // row's instructor_review_status flips from 'not_started' to 'submitted'.
-  const handleBeginCalibrationReview = useCallback(
-    (mapId: number | string | null | undefined) => {
-      if (!assignmentData?.id || !mapId) return;
-      sendBeginCalibrationRequest({
-        url: `/assignments/${assignmentData.id}/review_mappings/${mapId}/mock_instructor_response`,
-        method: HttpMethod.POST,
-      }).catch(() => {
-        // useAPI already surfaces the error into beginCalibrationError.
-      });
-    },
-    [assignmentData?.id, sendBeginCalibrationRequest]
-  );
-
-  // DEMO_INSTRUCTOR_RESPONSE: success/error effects for the demo seeder.
-  useEffect(() => {
-    if (beginCalibrationResponse && beginCalibrationResponse.status >= 200 && beginCalibrationResponse.status < 300) {
-      dispatch(alertActions.showAlert({ variant: "success", message: "Mock instructor and peer calibration responses submitted" }));
-      refreshCalibrationParticipants();
-    }
-  }, [beginCalibrationResponse, dispatch, refreshCalibrationParticipants]);
-
-  // DEMO_INSTRUCTOR_RESPONSE
-  useEffect(() => {
-    beginCalibrationError && dispatch(alertActions.showAlert({ variant: "danger", message: beginCalibrationError }));
-  }, [beginCalibrationError, dispatch]);
+  // DEMO_INSTRUCTOR_RESPONSE: remove this call (and the import above) when the
+  // real review form ships. See useCalibrationInstructorDemo for the full
+  // removal checklist.
+  const { handleBeginCalibrationReview } = useCalibrationInstructorDemo({
+    assignmentId: assignmentData?.id,
+    onSuccess: refreshCalibrationParticipants,
+  });
 
 
   const onSubmit = (
@@ -1288,7 +1257,7 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
                     <label htmlFor="calibration-username" style={{ display: 'block', marginBottom: '0.25rem' }}>
                       Search by username
                     </label>
-                    <div style={{ display: 'flex', gap: '0.5rem', maxWidth: 420 }}>
+                    <div style={{ display: 'flex', gap: '0.5rem', maxWidth: 280 }}>
                       <input
                         id="calibration-username"
                         type="text"

--- a/src/pages/Assignments/AssignmentEditor.tsx
+++ b/src/pages/Assignments/AssignmentEditor.tsx
@@ -115,6 +115,15 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
   // and let us trigger reloads only after a mutation succeeds.
   const { data: addCalibrationResponse, error: addCalibrationError, sendRequest: sendAddCalibrationRequest } = useAPI();
   const { data: removeCalibrationResponse, error: removeCalibrationError, sendRequest: sendRemoveCalibrationRequest } = useAPI();
+  // DEMO_INSTRUCTOR_RESPONSE
+  // Demo-only: "Begin" on the Calibration tab seeds a mock instructor
+  // calibration response so the report has data to render. The real review
+  // form is out of scope of this project. When the real form ships, delete
+  // this hook, the handleBeginCalibrationReview callback, both useEffects
+  // that consume beginCalibrationResponse / beginCalibrationError, and
+  // switch the "Begin" button in the Review-column cell back to a plain
+  // anchor pointing at the real review URL.
+  const { data: beginCalibrationResponse, error: beginCalibrationError, sendRequest: sendBeginCalibrationRequest } = useAPI();
   const [courses, setCourses] = useState<any[]>([]);
   const [calibrationSubmissions, setCalibrationSubmissions] = useState<any[]>([]);
   const [calibrationUsername, setCalibrationUsername] = useState<string>("");
@@ -643,6 +652,38 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
     },
     [assignmentData?.id, sendRemoveCalibrationRequest]
   );
+
+  // DEMO_INSTRUCTOR_RESPONSE
+  // Demo-only: kick off a mock instructor calibration response when the
+  // instructor clicks "Begin" on a calibration row. The backend materializes
+  // a submitted Response with default answers so the calibration report has
+  // data to display. Once it returns, refresh the participant list so the
+  // row's instructor_review_status flips from 'not_started' to 'submitted'.
+  const handleBeginCalibrationReview = useCallback(
+    (mapId: number | string | null | undefined) => {
+      if (!assignmentData?.id || !mapId) return;
+      sendBeginCalibrationRequest({
+        url: `/assignments/${assignmentData.id}/review_mappings/${mapId}/mock_instructor_response`,
+        method: HttpMethod.POST,
+      }).catch(() => {
+        // useAPI already surfaces the error into beginCalibrationError.
+      });
+    },
+    [assignmentData?.id, sendBeginCalibrationRequest]
+  );
+
+  // DEMO_INSTRUCTOR_RESPONSE: success/error effects for the demo seeder.
+  useEffect(() => {
+    if (beginCalibrationResponse && beginCalibrationResponse.status >= 200 && beginCalibrationResponse.status < 300) {
+      dispatch(alertActions.showAlert({ variant: "success", message: "Mock instructor and peer calibration responses submitted" }));
+      refreshCalibrationParticipants();
+    }
+  }, [beginCalibrationResponse, dispatch, refreshCalibrationParticipants]);
+
+  // DEMO_INSTRUCTOR_RESPONSE
+  useEffect(() => {
+    beginCalibrationError && dispatch(alertActions.showAlert({ variant: "danger", message: beginCalibrationError }));
+  }, [beginCalibrationError, dispatch]);
 
 
   const onSubmit = (
@@ -1295,10 +1336,13 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
                             accessorKey: "participant_name", header: "Participant name", enableSorting: false, enableColumnFilter: false
                           },
                           {
-                            // Review column links point at routes assumed to be provided by
-                            // the existing review-flow (out of scope for this project). When
-                            // no instructor review exists yet we show a single "Begin" link;
-                            // once a response exists we show "View | Edit".
+                            // Review column. The real review form is out of scope of this
+                            // project, so:
+                            //   - "Begin" posts to the demo endpoint that seeds a mock
+                            //     instructor calibration response, then the row refreshes
+                            //     and flips to "View | Edit".
+                            //   - "View | Edit" link to placeholder routes assumed to be
+                            //     provided by the existing review flow.
                             cell: ({ row }) => {
                               const mapId = row.original.instructor_review_map_id;
                               const status = row.original.instructor_review_status;
@@ -1308,7 +1352,28 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
                               const linkStyle: React.CSSProperties = { color: '#986633', textDecoration: 'none' };
 
                               if (status === 'not_started') {
-                                return <a style={linkStyle} href={`${reviewBase}/begin`}>Begin</a>;
+                                // DEMO_INSTRUCTOR_RESPONSE: when the real review
+                                // form ships, replace this button with a plain
+                                // <a style={linkStyle} href={`${reviewBase}/begin`}>Begin</a>
+                                // and remove handleBeginCalibrationReview.
+                                const beginStyle: React.CSSProperties = {
+                                  ...linkStyle,
+                                  background: 'none',
+                                  border: 'none',
+                                  padding: 0,
+                                  cursor: mapId ? 'pointer' : 'not-allowed',
+                                  font: 'inherit',
+                                };
+                                return (
+                                  <button
+                                    type="button"
+                                    style={beginStyle}
+                                    disabled={!mapId}
+                                    onClick={() => handleBeginCalibrationReview(mapId)}
+                                  >
+                                    Begin
+                                  </button>
+                                );
                               }
 
                               return (

--- a/src/pages/Assignments/AssignmentEditor.tsx
+++ b/src/pages/Assignments/AssignmentEditor.tsx
@@ -571,11 +571,16 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
         ? body
         : (body.calibration_participants || []);
       setCalibrationSubmissions(
-        rows.map((row: any) => ({
-          participant_id: row.participant_id,
-          participant_name: row.full_name || row.username || row.handle || `Participant ${row.participant_id}`,
-          submitted_content: row.submissions || { hyperlinks: [], files: [] },
-        }))
+        rows.map((row: any) => {
+          const personName = row.full_name || row.username || row.handle || `Participant ${row.participant_id}`;
+          return {
+            participant_id: row.participant_id,
+            participant_name: row.team_name || `Team_${personName}`,
+            instructor_review_map_id: row.instructor_review_map_id,
+            instructor_review_status: row.instructor_review_status || 'not_started',
+            submitted_content: row.submissions || { hyperlinks: [], files: [] },
+          };
+        })
       );
     }
   }, [calibrationSubmissionsResponse]);
@@ -1235,38 +1240,42 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
 
               </Tab>
 
-              {/* Calibration Tab */}
+              {/* Calibration Tab A team is created for the submitter and an
+                    instructor calibration review map is opened automatically.*/}
                 <Tab eventKey="calibration" title="Calibration">
-                  <h3>Calibration submitters</h3>
-                  <p className="text-muted" style={{ maxWidth: 720 }}>
-                    Designate one or more users whose submissions will be used for calibration reviews.
-                    Enter a username or email below. A team is created for the submitter and an
-                    instructor calibration review map is opened automatically.
-                  </p>
-
-                  <div style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', marginTop: '1rem', marginBottom: '1.5rem', maxWidth: 520 }}>
-                    <input
-                      type="text"
-                      className="form-control"
-                      placeholder="Username or email"
-                      value={calibrationUsername}
-                      onChange={(e) => setCalibrationUsername(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
-                          e.preventDefault();
-                          handleAddCalibrationParticipant();
-                        }
-                      }}
-                      aria-label="Calibration participant username"
-                    />
-                    <Button
-                      variant="primary"
-                      onClick={handleAddCalibrationParticipant}
-                      disabled={!calibrationUsername.trim()}
-                    >
-                      Add
-                    </Button>
+                  <div style={{ marginTop: '0.5rem', marginBottom: '1.5rem' }}>
+                    <label htmlFor="calibration-username" style={{ display: 'block', marginBottom: '0.25rem' }}>
+                      Search by username
+                    </label>
+                    <div style={{ display: 'flex', gap: '0.5rem', maxWidth: 420 }}>
+                      <input
+                        id="calibration-username"
+                        type="text"
+                        className="form-control"
+                        placeholder="Enter username"
+                        value={calibrationUsername}
+                        onChange={(e) => setCalibrationUsername(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') {
+                            e.preventDefault();
+                            handleAddCalibrationParticipant();
+                          }
+                        }}
+                        aria-label="Calibration participant username"
+                        style={{ flex: 1, height: 38, lineHeight: '1.5', padding: '0.375rem 0.75rem', boxSizing: 'border-box' }}
+                      />
+                      <Button
+                        variant="outline-secondary"
+                        onClick={handleAddCalibrationParticipant}
+                        disabled={!calibrationUsername.trim()}
+                        style={{ height: 38, lineHeight: 1, padding: '0 1rem', boxSizing: 'border-box' }}
+                      >
+                        Add
+                      </Button>
+                    </div>
                   </div>
+
+                  <h3 style={{ marginTop: '1.5rem' }}>Select participants for submitting calibration artifacts</h3>
 
                   <div>
                     <div style={{ display: 'ruby', marginTop: '30px' }}>
@@ -1277,11 +1286,54 @@ const AssignmentEditor: React.FC<IEditor> = ({ mode }) => {
                         data={calibrationSubmissions.map((calibrationSubmission: any) => ({
                           participant_id: calibrationSubmission.participant_id,
                           participant_name: calibrationSubmission.participant_name,
+                          instructor_review_map_id: calibrationSubmission.instructor_review_map_id,
+                          instructor_review_status: calibrationSubmission.instructor_review_status,
                           submitted_content: calibrationSubmission.submitted_content,
                         }))}
                         columns={[
                           {
                             accessorKey: "participant_name", header: "Participant name", enableSorting: false, enableColumnFilter: false
+                          },
+                          {
+                            // Review column links point at routes assumed to be provided by
+                            // the existing review-flow (out of scope for this project). When
+                            // no instructor review exists yet we show a single "Begin" link;
+                            // once a response exists we show "View | Edit".
+                            cell: ({ row }) => {
+                              const mapId = row.original.instructor_review_map_id;
+                              const status = row.original.instructor_review_status;
+                              const reviewBase = mapId
+                                ? `/assignments/edit/${assignmentData.id}/calibration/${mapId}`
+                                : '#';
+                              const linkStyle: React.CSSProperties = { color: '#986633', textDecoration: 'none' };
+
+                              if (status === 'not_started') {
+                                return <a style={linkStyle} href={`${reviewBase}/begin`}>Begin</a>;
+                              }
+
+                              return (
+                                <span>
+                                  <a style={linkStyle} href={`${reviewBase}/view`}>View</a>
+                                  <span style={{ margin: '0 0.4rem', color: '#986633' }}>|</span>
+                                  <a style={linkStyle} href={`${reviewBase}/edit`}>Edit</a>
+                                </span>
+                              );
+                            },
+                            accessorKey: "review", header: "Review", enableSorting: false, enableColumnFilter: false
+                          },
+                          {
+                            cell: ({ row }) => {
+                              const mapId = row.original.instructor_review_map_id;
+                              const href = mapId
+                                ? `/assignments/edit/${assignmentData.id}/calibration/${mapId}`
+                                : '#';
+                              return (
+                                <a style={{ color: '#986633', textDecoration: 'none' }} href={href}>
+                                  View review report
+                                </a>
+                              );
+                            },
+                            accessorKey: "report", header: "Report", enableSorting: false, enableColumnFilter: false
                           },
                           {
                             cell: ({ row }) => (

--- a/src/pages/Assignments/CalibrationReview.tsx
+++ b/src/pages/Assignments/CalibrationReview.tsx
@@ -1,8 +1,52 @@
-import { Container } from "react-bootstrap";
+import { useEffect, useState } from "react";
+import { Alert, Container, ListGroup, Spinner } from "react-bootstrap";
 import { Link, useParams } from "react-router-dom";
+import axiosClient from "../../utils/axios_client";
+
+interface CalibrationReportResponse {
+  map_id: number;
+  assignment_id: number;
+  reviewee_id: number;
+  rubric_items: unknown[];
+  instructor_response: unknown;
+  student_responses: unknown[];
+  per_item_summary: unknown[];
+  submitted_content?: {
+    hyperlinks?: string[];
+    files?: string[];
+  };
+}
 
 const CalibrationReview = () => {
   const { assignmentId, mapId } = useParams();
+  const [report, setReport] = useState<CalibrationReportResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadReport = async () => {
+      if (!assignmentId || !mapId) {
+        setError("Missing assignment or calibration map id.");
+        setLoading(false);
+        return;
+      }
+
+      try {
+        setLoading(true);
+        setError(null);
+        const response = await axiosClient.get<CalibrationReportResponse>(
+          `/assignments/${assignmentId}/review_mappings/${mapId}/calibration_report`
+        );
+        setReport(response.data);
+      } catch (err: any) {
+        setError(err?.response?.data?.error || "Unable to load calibration report");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadReport();
+  }, [assignmentId, mapId]);
 
   return (
     <Container className="py-4">
@@ -10,11 +54,53 @@ const CalibrationReview = () => {
       <p className="text-muted mb-4">
         Assignment {assignmentId}, calibration map {mapId}
       </p>
-      <p>
-        This page is the entry point for the calibration report UI. The next step
-        is to fetch <code>calibration_report</code> and render the class comparison
-        chart plus the rubric-detail comparison view.
-      </p>
+
+      {loading && (
+        <div className="d-flex align-items-center gap-2 mb-4">
+          <Spinner animation="border" size="sm" />
+          <span>Loading calibration report...</span>
+        </div>
+      )}
+
+      {!loading && error && (
+        <Alert variant="danger">
+          <Alert.Heading>Unable to load calibration report</Alert.Heading>
+          <div>{error}</div>
+        </Alert>
+      )}
+
+      {!loading && !error && report && (
+        <>
+          <Alert variant="success">
+            Calibration report loaded. This confirms the route and backend payload are wired.
+          </Alert>
+
+          <ListGroup className="mb-4">
+            <ListGroup.Item>
+              <strong>Map ID:</strong> {report.map_id}
+            </ListGroup.Item>
+            <ListGroup.Item>
+              <strong>Reviewee ID:</strong> {report.reviewee_id}
+            </ListGroup.Item>
+            <ListGroup.Item>
+              <strong>Rubric items:</strong> {report.rubric_items.length}
+            </ListGroup.Item>
+            <ListGroup.Item>
+              <strong>Student responses:</strong> {report.student_responses.length}
+            </ListGroup.Item>
+            <ListGroup.Item>
+              <strong>Per-item summaries:</strong> {report.per_item_summary.length}
+            </ListGroup.Item>
+            <ListGroup.Item>
+              <strong>Submitted hyperlinks:</strong> {report.submitted_content?.hyperlinks?.length ?? 0}
+            </ListGroup.Item>
+            <ListGroup.Item>
+              <strong>Submitted files:</strong> {report.submitted_content?.files?.length ?? 0}
+            </ListGroup.Item>
+          </ListGroup>
+        </>
+      )}
+
       <Link to={assignmentId ? `/assignments/edit/${assignmentId}` : "/assignments"}>
         Back to assignment
       </Link>

--- a/src/pages/Assignments/CalibrationReview.tsx
+++ b/src/pages/Assignments/CalibrationReview.tsx
@@ -1,0 +1,25 @@
+import { Container } from "react-bootstrap";
+import { Link, useParams } from "react-router-dom";
+
+const CalibrationReview = () => {
+  const { assignmentId, mapId } = useParams();
+
+  return (
+    <Container className="py-4">
+      <h1>Calibration Report</h1>
+      <p className="text-muted mb-4">
+        Assignment {assignmentId}, calibration map {mapId}
+      </p>
+      <p>
+        This page is the entry point for the calibration report UI. The next step
+        is to fetch <code>calibration_report</code> and render the class comparison
+        chart plus the rubric-detail comparison view.
+      </p>
+      <Link to={assignmentId ? `/assignments/edit/${assignmentId}` : "/assignments"}>
+        Back to assignment
+      </Link>
+    </Container>
+  );
+};
+
+export default CalibrationReview;

--- a/src/pages/Assignments/CalibrationReview.tsx
+++ b/src/pages/Assignments/CalibrationReview.tsx
@@ -6,6 +6,7 @@ import {
   normalizeCalibrationReport,
   type CalibrationReportResponse,
 } from "./calibrationReportNormalize";
+import CalibrationStackedChart from "./components/CalibrationStackedChart";
 
 const CalibrationReview = () => {
   const { assignmentId, mapId } = useParams();
@@ -66,6 +67,11 @@ const CalibrationReview = () => {
           <Alert variant="success">
             Calibration report loaded. This confirms the route and backend payload are wired.
           </Alert>
+
+          <CalibrationStackedChart
+            bucketKeys={normalizedReport.bucketKeys}
+            chartData={normalizedReport.stackedChartData}
+          />
 
           <ListGroup className="mb-4">
             <ListGroup.Item>

--- a/src/pages/Assignments/CalibrationReview.tsx
+++ b/src/pages/Assignments/CalibrationReview.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Alert, Container, ListGroup, Spinner } from "react-bootstrap";
+import { Alert, Card, Container, Spinner } from "react-bootstrap";
 import { Link, useParams } from "react-router-dom";
 import axiosClient from "../../utils/axios_client";
 import {
@@ -26,7 +26,7 @@ const CalibrationReview = () => {
         setLoading(true);
         setError(null);
         const response = await axiosClient.get<CalibrationReportResponse>(
-          `/assignments/${assignmentId}/review_mappings/${mapId}/calibration_report`
+          `/assignments/${assignmentId}/reports/calibration/${mapId}`
         );
         setReport(response.data);
       } catch (err: any) {
@@ -40,13 +40,31 @@ const CalibrationReview = () => {
   }, [assignmentId, mapId]);
 
   const normalizedReport = report ? normalizeCalibrationReport(report) : null;
+  const studentResponseCount = normalizedReport?.latestStudentResponses.length ?? 0;
+  const hyperlinks = report?.submitted_content?.hyperlinks ?? [];
+  const files = report?.submitted_content?.files ?? [];
+  const hasSubmittedContent = hyperlinks.length > 0 || files.length > 0;
+  const backHref = assignmentId ? `/assignments/edit/${assignmentId}` : "/assignments";
 
   return (
-    <Container className="py-4">
-      <h1>Calibration Report</h1>
-      <p className="text-muted mb-4">
-        Assignment {assignmentId}, calibration map {mapId}
-      </p>
+    <Container fluid className="py-4 px-4">
+      <div className="d-flex justify-content-between align-items-start flex-wrap gap-3 mb-4">
+        <div>
+          <h1 className="mb-1">Calibration Report</h1>
+          <p className="text-muted mb-0">
+            Assignment {assignmentId} · Calibration map {mapId}
+            {report && (
+              <>
+                {" "}
+                · {studentResponseCount} student response{studentResponseCount === 1 ? "" : "s"}
+              </>
+            )}
+          </p>
+        </div>
+        <Link to={backHref} className="btn btn-outline-secondary btn-sm">
+          ← Back to assignment
+        </Link>
+      </div>
 
       {loading && (
         <div className="d-flex align-items-center gap-2 mb-4">
@@ -64,50 +82,44 @@ const CalibrationReview = () => {
 
       {!loading && !error && report && normalizedReport && (
         <>
-          <Alert variant="success">
-            Calibration report loaded. This confirms the route and backend payload are wired.
-          </Alert>
-
           <CalibrationStackedChart
             bucketKeys={normalizedReport.bucketKeys}
             chartData={normalizedReport.stackedChartData}
           />
 
-          <ListGroup className="mb-4">
-            <ListGroup.Item>
-              <strong>Map ID:</strong> {report.map_id}
-            </ListGroup.Item>
-            <ListGroup.Item>
-              <strong>Reviewee ID:</strong> {report.reviewee_id}
-            </ListGroup.Item>
-            <ListGroup.Item>
-              <strong>Rubric items:</strong> {normalizedReport.rubricDetailRows.length}
-            </ListGroup.Item>
-            <ListGroup.Item>
-              <strong>Student responses:</strong> {normalizedReport.latestStudentResponses.length}
-            </ListGroup.Item>
-            <ListGroup.Item>
-              <strong>Per-item summaries:</strong> {normalizedReport.stackedChartData.length}
-            </ListGroup.Item>
-            <ListGroup.Item>
-              <strong>Reviewer options:</strong> {normalizedReport.reviewerOptions.length}
-            </ListGroup.Item>
-            <ListGroup.Item>
-              <strong>Default rubric-detail rows:</strong> {normalizedReport.rubricDetailRows.length}
-            </ListGroup.Item>
-            <ListGroup.Item>
-              <strong>Submitted hyperlinks:</strong> {report.submitted_content?.hyperlinks?.length ?? 0}
-            </ListGroup.Item>
-            <ListGroup.Item>
-              <strong>Submitted files:</strong> {report.submitted_content?.files?.length ?? 0}
-            </ListGroup.Item>
-          </ListGroup>
+          {hasSubmittedContent && (
+            <Card className="mb-4">
+              <Card.Body>
+                <Card.Title as="h5">Submitted content</Card.Title>
+                {hyperlinks.length > 0 && (
+                  <>
+                    <h6 className="mt-3 mb-2 text-muted">Hyperlinks</h6>
+                    <ul className="mb-3">
+                      {hyperlinks.map((link, idx) => (
+                        <li key={`${link}-${idx}`}>
+                          <a href={link} target="_blank" rel="noopener noreferrer">
+                            {link}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </>
+                )}
+                {files.length > 0 && (
+                  <>
+                    <h6 className="mt-3 mb-2 text-muted">Files</h6>
+                    <ul className="mb-0">
+                      {files.map((file, idx) => (
+                        <li key={`${file}-${idx}`}>{file}</li>
+                      ))}
+                    </ul>
+                  </>
+                )}
+              </Card.Body>
+            </Card>
+          )}
         </>
       )}
-
-      <Link to={assignmentId ? `/assignments/edit/${assignmentId}` : "/assignments"}>
-        Back to assignment
-      </Link>
     </Container>
   );
 };

--- a/src/pages/Assignments/CalibrationReview.tsx
+++ b/src/pages/Assignments/CalibrationReview.tsx
@@ -2,20 +2,10 @@ import { useEffect, useState } from "react";
 import { Alert, Container, ListGroup, Spinner } from "react-bootstrap";
 import { Link, useParams } from "react-router-dom";
 import axiosClient from "../../utils/axios_client";
-
-interface CalibrationReportResponse {
-  map_id: number;
-  assignment_id: number;
-  reviewee_id: number;
-  rubric_items: unknown[];
-  instructor_response: unknown;
-  student_responses: unknown[];
-  per_item_summary: unknown[];
-  submitted_content?: {
-    hyperlinks?: string[];
-    files?: string[];
-  };
-}
+import {
+  normalizeCalibrationReport,
+  type CalibrationReportResponse,
+} from "./calibrationReportNormalize";
 
 const CalibrationReview = () => {
   const { assignmentId, mapId } = useParams();
@@ -48,6 +38,8 @@ const CalibrationReview = () => {
     loadReport();
   }, [assignmentId, mapId]);
 
+  const normalizedReport = report ? normalizeCalibrationReport(report) : null;
+
   return (
     <Container className="py-4">
       <h1>Calibration Report</h1>
@@ -69,7 +61,7 @@ const CalibrationReview = () => {
         </Alert>
       )}
 
-      {!loading && !error && report && (
+      {!loading && !error && report && normalizedReport && (
         <>
           <Alert variant="success">
             Calibration report loaded. This confirms the route and backend payload are wired.
@@ -83,13 +75,19 @@ const CalibrationReview = () => {
               <strong>Reviewee ID:</strong> {report.reviewee_id}
             </ListGroup.Item>
             <ListGroup.Item>
-              <strong>Rubric items:</strong> {report.rubric_items.length}
+              <strong>Rubric items:</strong> {normalizedReport.rubricDetailRows.length}
             </ListGroup.Item>
             <ListGroup.Item>
-              <strong>Student responses:</strong> {report.student_responses.length}
+              <strong>Student responses:</strong> {normalizedReport.latestStudentResponses.length}
             </ListGroup.Item>
             <ListGroup.Item>
-              <strong>Per-item summaries:</strong> {report.per_item_summary.length}
+              <strong>Per-item summaries:</strong> {normalizedReport.stackedChartData.length}
+            </ListGroup.Item>
+            <ListGroup.Item>
+              <strong>Reviewer options:</strong> {normalizedReport.reviewerOptions.length}
+            </ListGroup.Item>
+            <ListGroup.Item>
+              <strong>Default rubric-detail rows:</strong> {normalizedReport.rubricDetailRows.length}
             </ListGroup.Item>
             <ListGroup.Item>
               <strong>Submitted hyperlinks:</strong> {report.submitted_content?.hyperlinks?.length ?? 0}

--- a/src/pages/Assignments/CalibrationReview.tsx
+++ b/src/pages/Assignments/CalibrationReview.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Alert, Card, Container, Spinner } from "react-bootstrap";
+import { Alert, Card, Container, Spinner, Tab, Tabs } from "react-bootstrap";
 import { Link, useParams } from "react-router-dom";
 import axiosClient from "../../utils/axios_client";
 import {
@@ -7,12 +7,15 @@ import {
   type CalibrationReportResponse,
 } from "./calibrationReportNormalize";
 import CalibrationStackedChart from "./components/CalibrationStackedChart";
+import CalibrationRubricDetailPanel from "./components/CalibrationRubricDetailPanel";
 
 const CalibrationReview = () => {
   const { assignmentId, mapId } = useParams();
   const [report, setReport] = useState<CalibrationReportResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [selectedReviewerId, setSelectedReviewerId] = useState<number | null>(null);
+  const [activeTab, setActiveTab] = useState("comparison");
 
   useEffect(() => {
     const loadReport = async () => {
@@ -40,11 +43,19 @@ const CalibrationReview = () => {
   }, [assignmentId, mapId]);
 
   const normalizedReport = report ? normalizeCalibrationReport(report) : null;
+  useEffect(() => {
+    setSelectedReviewerId(normalizedReport?.defaultReviewerId ?? null);
+  }, [normalizedReport?.defaultReviewerId]);
+
   const studentResponseCount = normalizedReport?.latestStudentResponses.length ?? 0;
   const hyperlinks = report?.submitted_content?.hyperlinks ?? [];
   const files = report?.submitted_content?.files ?? [];
   const hasSubmittedContent = hyperlinks.length > 0 || files.length > 0;
   const backHref = assignmentId ? `/assignments/edit/${assignmentId}` : "/assignments";
+  const rubricDetailRows =
+    normalizedReport && selectedReviewerId
+      ? normalizedReport.rubricDetailRowsByReviewer[selectedReviewerId] ?? normalizedReport.rubricDetailRows
+      : normalizedReport?.rubricDetailRows ?? [];
 
   return (
     <Container fluid className="py-4 px-4">
@@ -82,42 +93,63 @@ const CalibrationReview = () => {
 
       {!loading && !error && report && normalizedReport && (
         <>
-          <CalibrationStackedChart
-            bucketKeys={normalizedReport.bucketKeys}
-            chartData={normalizedReport.stackedChartData}
-          />
+          <Tabs
+            activeKey={activeTab}
+            className="mb-4"
+            id="calibration-report-tabs"
+            onSelect={(key) => setActiveTab(key ?? "comparison")}
+          >
+            <Tab eventKey="comparison" title="Class comparison (stacked)">
+              <div className="pt-3">
+                <CalibrationStackedChart
+                  bucketKeys={normalizedReport.bucketKeys}
+                  chartData={normalizedReport.stackedChartData}
+                />
+              </div>
+            </Tab>
+            <Tab eventKey="detail" title="Rubric detail">
+              <div className="pt-3">
+                <CalibrationRubricDetailPanel
+                  reviewerOptions={normalizedReport.reviewerOptions}
+                  selectedReviewerId={selectedReviewerId}
+                  rows={rubricDetailRows}
+                  onReviewerChange={setSelectedReviewerId}
+                />
 
-          {hasSubmittedContent && (
-            <Card className="mb-4">
-              <Card.Body>
-                <Card.Title as="h5">Submitted content</Card.Title>
-                {hyperlinks.length > 0 && (
-                  <>
-                    <h6 className="mt-3 mb-2 text-muted">Hyperlinks</h6>
-                    <ul className="mb-3">
-                      {hyperlinks.map((link, idx) => (
-                        <li key={`${link}-${idx}`}>
-                          <a href={link} target="_blank" rel="noopener noreferrer">
-                            {link}
-                          </a>
-                        </li>
-                      ))}
-                    </ul>
-                  </>
+                {hasSubmittedContent && (
+                  <Card className="mb-4">
+                    <Card.Body>
+                      <Card.Title as="h5">Submitted content</Card.Title>
+                      {hyperlinks.length > 0 && (
+                        <>
+                          <h6 className="mt-3 mb-2 text-muted">Hyperlinks</h6>
+                          <ul className="mb-3">
+                            {hyperlinks.map((link, idx) => (
+                              <li key={`${link}-${idx}`}>
+                                <a href={link} target="_blank" rel="noopener noreferrer">
+                                  {link}
+                                </a>
+                              </li>
+                            ))}
+                          </ul>
+                        </>
+                      )}
+                      {files.length > 0 && (
+                        <>
+                          <h6 className="mt-3 mb-2 text-muted">Files</h6>
+                          <ul className="mb-0">
+                            {files.map((file, idx) => (
+                              <li key={`${file}-${idx}`}>{file}</li>
+                            ))}
+                          </ul>
+                        </>
+                      )}
+                    </Card.Body>
+                  </Card>
                 )}
-                {files.length > 0 && (
-                  <>
-                    <h6 className="mt-3 mb-2 text-muted">Files</h6>
-                    <ul className="mb-0">
-                      {files.map((file, idx) => (
-                        <li key={`${file}-${idx}`}>{file}</li>
-                      ))}
-                    </ul>
-                  </>
-                )}
-              </Card.Body>
-            </Card>
-          )}
+              </div>
+            </Tab>
+          </Tabs>
         </>
       )}
     </Container>

--- a/src/pages/Assignments/__tests__/CalibrationReview.test.tsx
+++ b/src/pages/Assignments/__tests__/CalibrationReview.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { vi } from "vitest";
+import CalibrationReview from "../CalibrationReview";
+
+const { mockGet } = vi.hoisted(() => ({ mockGet: vi.fn() }));
+vi.mock("../../../utils/axios_client", () => ({
+  default: { get: mockGet },
+}));
+
+const mockReport = {
+  map_id: 8,
+  assignment_id: 1,
+  reviewee_id: 5,
+  rubric_items: [{ id: 11, txt: "Code quality", seq: 1, min_score: 0, max_score: 5 }],
+  instructor_response: {
+    id: 21,
+    map_id: 8,
+    reviewer_id: 15,
+    reviewer_name: "instructor",
+    is_submitted: true,
+    updated_at: "2026-04-23T16:00:00Z",
+    answers: [{ item_id: 11, score: 4, comments: "Good code" }],
+  },
+  student_responses: [
+    {
+      id: 31,
+      map_id: 9,
+      reviewer_id: 22,
+      reviewer_name: "Student A",
+      is_submitted: true,
+      updated_at: "2026-04-23T16:00:00Z",
+      answers: [{ item_id: 11, score: 3, comments: "Mostly good" }],
+    },
+  ],
+  per_item_summary: [
+    {
+      item_id: 11,
+      item_label: "Code quality",
+      item_seq: 1,
+      instructor_score: 4,
+      instructor_comment: "Good code",
+      bucket_counts: { "0": 0, "1": 0, "2": 0, "3": 1, "4": 0, "5": 0 },
+      student_response_count: 1,
+    },
+  ],
+  submitted_content: { hyperlinks: [], files: [] },
+};
+
+const renderPage = () =>
+  render(
+    <MemoryRouter initialEntries={["/assignments/1/calibration/8"]}>
+      <Routes>
+        <Route
+          path="/assignments/:assignmentId/calibration/:mapId"
+          element={<CalibrationReview />}
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+
+describe("CalibrationReview page", () => {
+  afterEach(() => vi.clearAllMocks());
+
+  test("shows loading spinner then renders report heading and student count on success", async () => {
+    mockGet.mockResolvedValueOnce({ data: mockReport } as any);
+
+    renderPage();
+
+    expect(screen.getByText(/loading calibration report/i)).toBeInTheDocument();
+
+    await waitFor(() =>
+      expect(screen.getByText(/calibration report/i)).toBeInTheDocument()
+    );
+    expect(screen.getByText(/1 student response/i)).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /class comparison/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /rubric detail/i })).toBeInTheDocument();
+  });
+
+  test("shows error alert when the API call fails", async () => {
+    mockGet.mockRejectedValueOnce({
+      response: { data: { error: "Not authorized" } },
+    });
+
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/unable to load calibration report/i)).toBeInTheDocument()
+    );
+    expect(screen.getByText("Not authorized")).toBeInTheDocument();
+  });
+});

--- a/src/pages/Assignments/__tests__/CalibrationRubricDetailPanel.test.tsx
+++ b/src/pages/Assignments/__tests__/CalibrationRubricDetailPanel.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import CalibrationRubricDetailPanel from "../components/CalibrationRubricDetailPanel";
+import type { ReviewerOption, RubricDetailRow } from "../calibrationReportNormalize";
+
+describe("CalibrationRubricDetailPanel", () => {
+  const reviewerOptions: ReviewerOption[] = [
+    { value: 21, label: "Reviewer Alpha", mapId: 9, responseId: 101 },
+    { value: 22, label: "Reviewer Beta", mapId: 10, responseId: 102 },
+  ];
+
+  const rowsByReviewer: Record<number, RubricDetailRow[]> = {
+    21: [
+      {
+        itemId: 1,
+        itemLabel: "Code quality",
+        itemSeq: 1,
+        instructorScore: 4,
+        instructorComment: "Clear implementation",
+        studentScore: 3,
+        studentComment: "Mostly clear",
+        agreeCount: 2,
+        nearCount: 3,
+        disagreeCount: 1,
+        noScoreCount: 0,
+        totalResponses: 6,
+        averageScore: 3.2,
+      },
+    ],
+    22: [
+      {
+        itemId: 1,
+        itemLabel: "Code quality",
+        itemSeq: 1,
+        instructorScore: 4,
+        instructorComment: "",
+        studentScore: null,
+        studentComment: "",
+        agreeCount: 1,
+        nearCount: 1,
+        disagreeCount: 2,
+        noScoreCount: 2,
+        totalResponses: 6,
+        averageScore: 2.5,
+      },
+    ],
+  };
+
+  const PanelHarness = () => {
+    const [selectedReviewerId, setSelectedReviewerId] = useState<number | null>(21);
+
+    return (
+      <CalibrationRubricDetailPanel
+        reviewerOptions={reviewerOptions}
+        selectedReviewerId={selectedReviewerId}
+        rows={selectedReviewerId ? rowsByReviewer[selectedReviewerId] : []}
+        onReviewerChange={setSelectedReviewerId}
+      />
+    );
+  };
+
+  test("renders the default reviewer comparison rows", () => {
+    render(<PanelHarness />);
+
+    expect(screen.getByText(/rubric detail/i)).toBeInTheDocument();
+    expect(screen.getByTestId("selected-reviewer-summary")).toHaveTextContent("Reviewer Alpha");
+    expect(screen.getByText("1. Code quality")).toBeInTheDocument();
+    expect(screen.getByText("Clear implementation")).toBeInTheDocument();
+    expect(screen.getByText("Mostly clear")).toBeInTheDocument();
+    expect(screen.getByText("1 below")).toBeInTheDocument();
+    expect(screen.getByText("Green Agree: 2")).toBeInTheDocument();
+    expect(screen.getByText("Yellow Near: 3")).toBeInTheDocument();
+    expect(screen.getByText("Red Disagree: 1")).toBeInTheDocument();
+  });
+
+  test("switches reviewers and updates the comparison rows", () => {
+    render(<PanelHarness />);
+
+    fireEvent.change(screen.getByLabelText(/student reviewer/i), {
+      target: { value: "22" },
+    });
+
+    expect(screen.getByTestId("selected-reviewer-summary")).toHaveTextContent("Reviewer Beta");
+    expect(screen.getAllByText("No comments")).toHaveLength(2);
+    expect(screen.getAllByText("N/A")).toHaveLength(2);
+  });
+});

--- a/src/pages/Assignments/__tests__/CalibrationStackedChart.test.tsx
+++ b/src/pages/Assignments/__tests__/CalibrationStackedChart.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import CalibrationStackedChart from "../components/CalibrationStackedChart";
+import type { StackedChartDataRow } from "../calibrationReportNormalize";
+
+describe("CalibrationStackedChart", () => {
+  const chartData: StackedChartDataRow[] = [
+    {
+      itemId: 11,
+      itemLabel: "Code quality",
+      itemSeq: 1,
+      instructorScore: 4,
+      agreeCount: 0,
+      nearCount: 1,
+      disagreeCount: 0,
+      totalResponses: 1,
+    },
+    {
+      itemId: 12,
+      itemLabel: "Documentation",
+      itemSeq: 2,
+      instructorScore: 5,
+      agreeCount: 0,
+      nearCount: 1,
+      disagreeCount: 0,
+      totalResponses: 1,
+    },
+  ];
+
+  test("renders chart title and instructor reference table", () => {
+    render(
+      <CalibrationStackedChart
+        bucketKeys={["agreeCount", "nearCount", "disagreeCount"]}
+        chartData={chartData}
+      />
+    );
+
+    expect(screen.getByText(/class comparison \(stacked\)/i)).toBeInTheDocument();
+    expect(screen.getByTestId("calibration-stacked-chart")).toBeInTheDocument();
+    expect(screen.getByText(/agree \(matches instructor score\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/near \(±1\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/disagree/i)).toBeInTheDocument();
+    expect(screen.getByText(/instructor reference scores/i)).toBeInTheDocument();
+    expect(screen.getByText("Code quality")).toBeInTheDocument();
+    expect(screen.getByText("Documentation")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(screen.getByText("5")).toBeInTheDocument();
+  });
+});

--- a/src/pages/Assignments/__tests__/calibrationReportNormalize.test.ts
+++ b/src/pages/Assignments/__tests__/calibrationReportNormalize.test.ts
@@ -1,0 +1,133 @@
+import {
+  normalizeCalibrationReport,
+  type CalibrationReportResponse,
+} from "../calibrationReportNormalize";
+
+describe("normalizeCalibrationReport", () => {
+  const report: CalibrationReportResponse = {
+    map_id: 8,
+    assignment_id: 8,
+    reviewee_id: 8,
+    rubric_items: [
+      { id: 11, txt: "Code quality", seq: 1, min_score: 0, max_score: 5 },
+      { id: 12, txt: "Documentation", seq: 2, min_score: 0, max_score: 5 },
+    ],
+    instructor_response: {
+      id: 21,
+      map_id: 8,
+      reviewer_id: 15,
+      reviewer_name: "admin",
+      is_submitted: true,
+      updated_at: "2026-04-23T16:00:00Z",
+      answers: [
+        { item_id: 11, score: 4, comments: "Instructor code" },
+        { item_id: 12, score: 5, comments: "Instructor docs" },
+      ],
+    },
+    student_responses: [
+      {
+        id: 31,
+        map_id: 9,
+        reviewer_id: 22,
+        reviewer_name: "Student A",
+        is_submitted: true,
+        updated_at: "2026-04-22T16:00:00Z",
+        answers: [
+          { item_id: 11, score: 2, comments: "Older code" },
+          { item_id: 12, score: 3, comments: "Older docs" },
+        ],
+      },
+      {
+        id: 32,
+        map_id: 9,
+        reviewer_id: 22,
+        reviewer_name: "Student A",
+        is_submitted: true,
+        updated_at: "2026-04-23T16:00:00Z",
+        answers: [
+          { item_id: 11, score: 3, comments: "Latest code" },
+          { item_id: 12, score: 4, comments: "Latest docs" },
+        ],
+      },
+    ],
+    per_item_summary: [
+      {
+        item_id: 11,
+        item_label: "Code quality",
+        item_seq: 1,
+        instructor_score: 4,
+        instructor_comment: "Instructor code",
+        bucket_counts: { "0": 0, "1": 0, "2": 0, "3": 1, "4": 0, "5": 0 },
+        student_response_count: 1,
+      },
+      {
+        item_id: 12,
+        item_label: "Documentation",
+        item_seq: 2,
+        instructor_score: 5,
+        instructor_comment: "Instructor docs",
+        bucket_counts: { "0": 0, "1": 0, "2": 0, "3": 0, "4": 1, "5": 0 },
+        student_response_count: 1,
+      },
+    ],
+    submitted_content: {
+      hyperlinks: ["https://example.com"],
+      files: ["submission.pdf"],
+    },
+  };
+
+  test("builds stacked chart rows from per-item summaries", () => {
+    const normalized = normalizeCalibrationReport(report);
+
+    expect(normalized.bucketKeys).toEqual([
+      "score_0",
+      "score_1",
+      "score_2",
+      "score_3",
+      "score_4",
+      "score_5",
+    ]);
+    expect(normalized.stackedChartData).toEqual([
+      expect.objectContaining({
+        itemId: 11,
+        itemLabel: "Code quality",
+        instructorScore: 4,
+        score_3: 1,
+      }),
+      expect.objectContaining({
+        itemId: 12,
+        itemLabel: "Documentation",
+        instructorScore: 5,
+        score_4: 1,
+      }),
+    ]);
+  });
+
+  test("uses the latest submitted student response for rubric detail data", () => {
+    const normalized = normalizeCalibrationReport(report);
+
+    expect(normalized.reviewerOptions).toEqual([
+      {
+        value: 22,
+        label: "Student A",
+        mapId: 9,
+        responseId: 32,
+      },
+    ]);
+    expect(normalized.defaultReviewerId).toBe(22);
+    expect(normalized.rubricDetailRows).toEqual([
+      expect.objectContaining({
+        itemId: 11,
+        instructorScore: 4,
+        studentScore: 3,
+        studentComment: "Latest code",
+      }),
+      expect.objectContaining({
+        itemId: 12,
+        instructorScore: 5,
+        studentScore: 4,
+        studentComment: "Latest docs",
+      }),
+    ]);
+  });
+});

--- a/src/pages/Assignments/__tests__/calibrationReportNormalize.test.ts
+++ b/src/pages/Assignments/__tests__/calibrationReportNormalize.test.ts
@@ -76,29 +76,26 @@ describe("normalizeCalibrationReport", () => {
     },
   };
 
-  test("builds stacked chart rows from per-item summaries", () => {
+  test("builds agreement buckets from per-item summaries relative to instructor score", () => {
     const normalized = normalizeCalibrationReport(report);
 
-    expect(normalized.bucketKeys).toEqual([
-      "score_0",
-      "score_1",
-      "score_2",
-      "score_3",
-      "score_4",
-      "score_5",
-    ]);
+    expect(normalized.bucketKeys).toEqual(["agreeCount", "nearCount", "disagreeCount"]);
     expect(normalized.stackedChartData).toEqual([
       expect.objectContaining({
         itemId: 11,
         itemLabel: "Code quality",
         instructorScore: 4,
-        score_3: 1,
+        agreeCount: 0,
+        nearCount: 1,
+        disagreeCount: 0,
       }),
       expect.objectContaining({
         itemId: 12,
         itemLabel: "Documentation",
         instructorScore: 5,
-        score_4: 1,
+        agreeCount: 0,
+        nearCount: 1,
+        disagreeCount: 0,
       }),
     ]);
   });

--- a/src/pages/Assignments/__tests__/calibrationReportNormalize.test.ts
+++ b/src/pages/Assignments/__tests__/calibrationReportNormalize.test.ts
@@ -101,6 +101,27 @@ describe("normalizeCalibrationReport", () => {
     ]);
   });
 
+  test("returns empty chart data when there are no student responses", () => {
+    const emptyReport: CalibrationReportResponse = {
+      ...report,
+      student_responses: [],
+      per_item_summary: report.per_item_summary.map((s) => ({
+        ...s,
+        bucket_counts: { "0": 0, "1": 0, "2": 0, "3": 0, "4": 0, "5": 0 },
+        student_response_count: 0,
+      })),
+    };
+    const normalized = normalizeCalibrationReport(emptyReport);
+
+    expect(normalized.reviewerOptions).toHaveLength(0);
+    expect(normalized.defaultReviewerId).toBeNull();
+    normalized.stackedChartData.forEach((row) => {
+      expect(row.agreeCount).toBe(0);
+      expect(row.nearCount).toBe(0);
+      expect(row.disagreeCount).toBe(0);
+    });
+  });
+
   test("uses the latest submitted student response for rubric detail data", () => {
     const normalized = normalizeCalibrationReport(report);
 

--- a/src/pages/Assignments/__tests__/calibrationReportNormalize.test.ts
+++ b/src/pages/Assignments/__tests__/calibrationReportNormalize.test.ts
@@ -46,7 +46,7 @@ describe("normalizeCalibrationReport", () => {
         updated_at: "2026-04-23T16:00:00Z",
         answers: [
           { item_id: 11, score: 3, comments: "Latest code" },
-          { item_id: 12, score: 4, comments: "Latest docs" },
+          { item_id: 12, score: null, comments: "" },
         ],
       },
     ],
@@ -66,7 +66,7 @@ describe("normalizeCalibrationReport", () => {
         item_seq: 2,
         instructor_score: 5,
         instructor_comment: "Instructor docs",
-        bucket_counts: { "0": 0, "1": 0, "2": 0, "3": 0, "4": 1, "5": 0 },
+        bucket_counts: { "0": 0, "1": 0, "2": 0, "3": 0, "4": 0, "5": 0 },
         student_response_count: 1,
       },
     ],
@@ -94,8 +94,9 @@ describe("normalizeCalibrationReport", () => {
         itemLabel: "Documentation",
         instructorScore: 5,
         agreeCount: 0,
-        nearCount: 1,
+        nearCount: 0,
         disagreeCount: 0,
+        totalResponses: 0,
       }),
     ]);
   });
@@ -118,12 +119,16 @@ describe("normalizeCalibrationReport", () => {
         instructorScore: 4,
         studentScore: 3,
         studentComment: "Latest code",
+        noScoreCount: 0,
+        averageScore: 3,
       }),
       expect.objectContaining({
         itemId: 12,
         instructorScore: 5,
-        studentScore: 4,
-        studentComment: "Latest docs",
+        studentScore: null,
+        studentComment: "",
+        noScoreCount: 1,
+        averageScore: null,
       }),
     ]);
   });

--- a/src/pages/Assignments/calibrationReportNormalize.ts
+++ b/src/pages/Assignments/calibrationReportNormalize.ts
@@ -74,6 +74,12 @@ export interface RubricDetailRow {
   instructorComment: string;
   studentScore: number | null;
   studentComment: string;
+  agreeCount: number;
+  nearCount: number;
+  disagreeCount: number;
+  noScoreCount: number;
+  totalResponses: number;
+  averageScore: number | null;
 }
 
 export interface NormalizedCalibrationReport {
@@ -141,16 +147,30 @@ const agreementCountFor = (
 const buildRubricRows = (
   rubricItems: CalibrationRubricItem[],
   instructorResponse: CalibrationResponse,
+  perItemSummary: CalibrationPerItemSummary[],
   studentResponse?: CalibrationResponse
 ) => {
   const instructorAnswers = buildAnswersByItem(instructorResponse.answers);
   const studentAnswers = studentResponse ? buildAnswersByItem(studentResponse.answers) : {};
+  const summaryByItem = perItemSummary.reduce<Record<number, CalibrationPerItemSummary>>((byItem, summary) => {
+    byItem[summary.item_id] = summary;
+    return byItem;
+  }, {});
 
   return [...rubricItems]
     .sort((left, right) => left.seq - right.seq)
     .map((item) => {
       const instructorAnswer = instructorAnswers[item.id];
       const studentAnswer = studentAnswers[item.id];
+      const summary = summaryByItem[item.id];
+      const totalScoredResponses = summary
+        ? Object.values(summary.bucket_counts).reduce((total, count) => total + count, 0)
+        : 0;
+      const totalResponses = summary?.student_response_count ?? 0;
+      const averageScore = summary && totalScoredResponses > 0
+        ? Object.entries(summary.bucket_counts).reduce((total, [score, count]) => total + Number(score) * count, 0) /
+          totalScoredResponses
+        : null;
 
       return {
         itemId: item.id,
@@ -160,6 +180,12 @@ const buildRubricRows = (
         instructorComment: instructorAnswer?.comments ?? "",
         studentScore: studentAnswer?.score ?? null,
         studentComment: studentAnswer?.comments ?? "",
+        agreeCount: summary ? agreementCountFor(summary, "agree") : 0,
+        nearCount: summary ? agreementCountFor(summary, "near") : 0,
+        disagreeCount: summary ? agreementCountFor(summary, "disagree") : 0,
+        noScoreCount: Math.max(0, totalResponses - totalScoredResponses),
+        totalResponses,
+        averageScore,
       };
     });
 };
@@ -199,6 +225,7 @@ export const normalizeCalibrationReport = (
       rowsByReviewer[response.reviewer_id] = buildRubricRows(
         report.rubric_items,
         report.instructor_response,
+        report.per_item_summary,
         response
       );
       return rowsByReviewer;
@@ -214,7 +241,7 @@ export const normalizeCalibrationReport = (
     reviewerOptions,
     rubricDetailRows: defaultReviewerId
       ? rubricDetailRowsByReviewer[defaultReviewerId]
-      : buildRubricRows(report.rubric_items, report.instructor_response),
+      : buildRubricRows(report.rubric_items, report.instructor_response, report.per_item_summary),
     rubricDetailRowsByReviewer,
     latestStudentResponses,
     defaultReviewerId,

--- a/src/pages/Assignments/calibrationReportNormalize.ts
+++ b/src/pages/Assignments/calibrationReportNormalize.ts
@@ -1,0 +1,204 @@
+export interface CalibrationAnswer {
+  item_id: number;
+  score: number | null;
+  comments?: string | null;
+}
+
+export interface CalibrationRubricItem {
+  id: number;
+  txt: string;
+  seq: number;
+  question_type?: string;
+  weight?: number;
+  min_score?: number;
+  max_score?: number;
+}
+
+export interface CalibrationResponse {
+  id: number;
+  map_id: number;
+  reviewer_id: number;
+  reviewer_name?: string | null;
+  is_submitted: boolean;
+  updated_at: string;
+  answers: CalibrationAnswer[];
+}
+
+export interface CalibrationPerItemSummary {
+  item_id: number;
+  item_label: string;
+  item_seq: number;
+  instructor_score: number | null;
+  instructor_comment?: string | null;
+  bucket_counts: Record<string, number>;
+  student_response_count: number;
+}
+
+export interface CalibrationReportResponse {
+  map_id: number;
+  assignment_id: number;
+  reviewee_id: number;
+  rubric_items: CalibrationRubricItem[];
+  instructor_response: CalibrationResponse;
+  student_responses: CalibrationResponse[];
+  per_item_summary: CalibrationPerItemSummary[];
+  submitted_content?: {
+    hyperlinks?: string[];
+    files?: string[];
+  };
+}
+
+export interface StackedChartDataRow {
+  itemId: number;
+  itemLabel: string;
+  itemSeq: number;
+  instructorScore: number | null;
+  [scoreBucket: string]: number | string | null;
+}
+
+export interface ReviewerOption {
+  value: number;
+  label: string;
+  mapId: number;
+  responseId: number;
+}
+
+export interface RubricDetailRow {
+  itemId: number;
+  itemLabel: string;
+  itemSeq: number;
+  instructorScore: number | null;
+  instructorComment: string;
+  studentScore: number | null;
+  studentComment: string;
+}
+
+export interface NormalizedCalibrationReport {
+  bucketKeys: string[];
+  stackedChartData: StackedChartDataRow[];
+  reviewerOptions: ReviewerOption[];
+  rubricDetailRows: RubricDetailRow[];
+  rubricDetailRowsByReviewer: Record<number, RubricDetailRow[]>;
+  latestStudentResponses: CalibrationResponse[];
+  defaultReviewerId: number | null;
+}
+
+const buildAnswersByItem = (answers: CalibrationAnswer[]) =>
+  answers.reduce<Record<number, CalibrationAnswer>>((byItem, answer) => {
+    byItem[answer.item_id] = answer;
+    return byItem;
+  }, {});
+
+const latestStudentResponsesForMaps = (responses: CalibrationResponse[]) =>
+  Object.values(
+    responses.reduce<Record<number, CalibrationResponse>>((latestByMap, response) => {
+      const current = latestByMap[response.map_id];
+
+      if (!current || new Date(response.updated_at).getTime() > new Date(current.updated_at).getTime()) {
+        latestByMap[response.map_id] = response;
+      }
+
+      return latestByMap;
+    }, {})
+  ).sort((left, right) => {
+    const leftName = left.reviewer_name ?? "";
+    const rightName = right.reviewer_name ?? "";
+    return leftName.localeCompare(rightName);
+  });
+
+const scoreBucketKey = (score: string) => `score_${score}`;
+
+const buildRubricRows = (
+  rubricItems: CalibrationRubricItem[],
+  instructorResponse: CalibrationResponse,
+  studentResponse?: CalibrationResponse
+) => {
+  const instructorAnswers = buildAnswersByItem(instructorResponse.answers);
+  const studentAnswers = studentResponse ? buildAnswersByItem(studentResponse.answers) : {};
+
+  return [...rubricItems]
+    .sort((left, right) => left.seq - right.seq)
+    .map((item) => {
+      const instructorAnswer = instructorAnswers[item.id];
+      const studentAnswer = studentAnswers[item.id];
+
+      return {
+        itemId: item.id,
+        itemLabel: item.txt,
+        itemSeq: item.seq,
+        instructorScore: instructorAnswer?.score ?? null,
+        instructorComment: instructorAnswer?.comments ?? "",
+        studentScore: studentAnswer?.score ?? null,
+        studentComment: studentAnswer?.comments ?? "",
+      };
+    });
+};
+
+export const normalizeCalibrationReport = (
+  report: CalibrationReportResponse
+): NormalizedCalibrationReport => {
+  const bucketKeys = Array.from(
+    new Set(
+      report.per_item_summary.flatMap((summary) =>
+        Object.keys(summary.bucket_counts)
+          .sort((left, right) => Number(left) - Number(right))
+          .map(scoreBucketKey)
+      )
+    )
+  ).sort((left, right) => Number(left.replace("score_", "")) - Number(right.replace("score_", "")));
+
+  const stackedChartData = [...report.per_item_summary]
+    .sort((left, right) => left.item_seq - right.item_seq)
+    .map((summary) => {
+      const row: StackedChartDataRow = {
+        itemId: summary.item_id,
+        itemLabel: summary.item_label,
+        itemSeq: summary.item_seq,
+        instructorScore: summary.instructor_score,
+      };
+
+      bucketKeys.forEach((key) => {
+        row[key] = 0;
+      });
+
+      Object.entries(summary.bucket_counts).forEach(([score, count]) => {
+        row[scoreBucketKey(score)] = count;
+      });
+
+      return row;
+    });
+
+  const latestStudentResponses = latestStudentResponsesForMaps(report.student_responses);
+  const reviewerOptions = latestStudentResponses.map((response) => ({
+    value: response.reviewer_id,
+    label: response.reviewer_name || `Reviewer ${response.reviewer_id}`,
+    mapId: response.map_id,
+    responseId: response.id,
+  }));
+
+  const rubricDetailRowsByReviewer = latestStudentResponses.reduce<Record<number, RubricDetailRow[]>>(
+    (rowsByReviewer, response) => {
+      rowsByReviewer[response.reviewer_id] = buildRubricRows(
+        report.rubric_items,
+        report.instructor_response,
+        response
+      );
+      return rowsByReviewer;
+    },
+    {}
+  );
+
+  const defaultReviewerId = reviewerOptions[0]?.value ?? null;
+
+  return {
+    bucketKeys,
+    stackedChartData,
+    reviewerOptions,
+    rubricDetailRows: defaultReviewerId
+      ? rubricDetailRowsByReviewer[defaultReviewerId]
+      : buildRubricRows(report.rubric_items, report.instructor_response),
+    rubricDetailRowsByReviewer,
+    latestStudentResponses,
+    defaultReviewerId,
+  };
+};

--- a/src/pages/Assignments/calibrationReportNormalize.ts
+++ b/src/pages/Assignments/calibrationReportNormalize.ts
@@ -53,7 +53,10 @@ export interface StackedChartDataRow {
   itemLabel: string;
   itemSeq: number;
   instructorScore: number | null;
-  [scoreBucket: string]: number | string | null;
+  agreeCount: number;
+  nearCount: number;
+  disagreeCount: number;
+  totalResponses: number;
 }
 
 export interface ReviewerOption {
@@ -108,6 +111,33 @@ const latestStudentResponsesForMaps = (responses: CalibrationResponse[]) =>
 
 const scoreBucketKey = (score: string) => `score_${score}`;
 
+const agreementCountFor = (
+  summary: CalibrationPerItemSummary,
+  classification: "agree" | "near" | "disagree"
+) => {
+  if (summary.instructor_score === null) {
+    return 0;
+  }
+
+  return Object.entries(summary.bucket_counts).reduce((count, [score, bucketCount]) => {
+    const distance = Math.abs(Number(score) - summary.instructor_score!);
+
+    if (classification === "agree" && distance === 0) {
+      return count + bucketCount;
+    }
+
+    if (classification === "near" && distance === 1) {
+      return count + bucketCount;
+    }
+
+    if (classification === "disagree" && distance > 1) {
+      return count + bucketCount;
+    }
+
+    return count;
+  }, 0);
+};
+
 const buildRubricRows = (
   rubricItems: CalibrationRubricItem[],
   instructorResponse: CalibrationResponse,
@@ -137,35 +167,23 @@ const buildRubricRows = (
 export const normalizeCalibrationReport = (
   report: CalibrationReportResponse
 ): NormalizedCalibrationReport => {
-  const bucketKeys = Array.from(
-    new Set(
-      report.per_item_summary.flatMap((summary) =>
-        Object.keys(summary.bucket_counts)
-          .sort((left, right) => Number(left) - Number(right))
-          .map(scoreBucketKey)
-      )
-    )
-  ).sort((left, right) => Number(left.replace("score_", "")) - Number(right.replace("score_", "")));
+  const bucketKeys = ["agreeCount", "nearCount", "disagreeCount"];
 
   const stackedChartData = [...report.per_item_summary]
     .sort((left, right) => left.item_seq - right.item_seq)
-    .map((summary) => {
-      const row: StackedChartDataRow = {
+    .map((summary): StackedChartDataRow => {
+      const totalResponses = Object.values(summary.bucket_counts).reduce((total, count) => total + count, 0);
+
+      return {
         itemId: summary.item_id,
         itemLabel: summary.item_label,
         itemSeq: summary.item_seq,
         instructorScore: summary.instructor_score,
+        agreeCount: agreementCountFor(summary, "agree"),
+        nearCount: agreementCountFor(summary, "near"),
+        disagreeCount: agreementCountFor(summary, "disagree"),
+        totalResponses,
       };
-
-      bucketKeys.forEach((key) => {
-        row[key] = 0;
-      });
-
-      Object.entries(summary.bucket_counts).forEach(([score, count]) => {
-        row[scoreBucketKey(score)] = count;
-      });
-
-      return row;
     });
 
   const latestStudentResponses = latestStudentResponsesForMaps(report.student_responses);

--- a/src/pages/Assignments/components/CalibrationRubricDetailPanel.tsx
+++ b/src/pages/Assignments/components/CalibrationRubricDetailPanel.tsx
@@ -1,0 +1,127 @@
+import { Card, Col, Form, Row, Table } from "react-bootstrap";
+import type { ReviewerOption, RubricDetailRow } from "../calibrationReportNormalize";
+import CalibrationRubricDistributionChart from "./CalibrationRubricDistributionChart";
+
+interface CalibrationRubricDetailPanelProps {
+  reviewerOptions: ReviewerOption[];
+  selectedReviewerId: number | null;
+  rows: RubricDetailRow[];
+  onReviewerChange: (reviewerId: number) => void;
+}
+
+const scoreLabel = (score: number | null) => (score === null ? "N/A" : score);
+
+const commentLabel = (comment: string) => comment.trim() || "No comments";
+
+const differenceLabel = (instructorScore: number | null, studentScore: number | null) => {
+  if (instructorScore === null || studentScore === null) {
+    return "N/A";
+  }
+
+  const difference = studentScore - instructorScore;
+
+  if (difference === 0) {
+    return "Matches instructor";
+  }
+
+  return `${Math.abs(difference)} ${difference > 0 ? "above" : "below"}`;
+};
+
+const CalibrationRubricDetailPanel = ({
+  reviewerOptions,
+  selectedReviewerId,
+  rows,
+  onReviewerChange,
+}: CalibrationRubricDetailPanelProps) => {
+  const selectedReviewer = reviewerOptions.find((option) => option.value === selectedReviewerId);
+
+  return (
+    <Card className="mb-4">
+      <Card.Body>
+        <div className="d-flex flex-column flex-md-row justify-content-between align-items-md-end gap-3 mb-3">
+          <div>
+            <Card.Title as="h5">Rubric detail</Card.Title>
+            <Card.Text className="text-muted mb-0">
+              Compare one student calibration review directly against the instructor on each rubric item.
+            </Card.Text>
+          </div>
+
+          <Form.Group controlId="calibration-reviewer-select" style={{ minWidth: 280 }}>
+            <Form.Label className="mb-1">Student reviewer</Form.Label>
+            <Form.Select
+              aria-label="Student reviewer"
+              disabled={reviewerOptions.length === 0}
+              value={selectedReviewerId ?? ""}
+              onChange={(event) => onReviewerChange(Number(event.target.value))}
+            >
+              {reviewerOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+        </div>
+
+        {selectedReviewer ? (
+          <p className="mb-3" data-testid="selected-reviewer-summary">
+            Comparing against <strong>{selectedReviewer.label}</strong>.
+          </p>
+        ) : (
+          <p className="text-muted mb-3">No student reviewer is available for comparison yet.</p>
+        )}
+
+        <div className="d-flex flex-column gap-4">
+          {rows.map((row) => (
+            <Card key={row.itemId} className="border">
+              <Card.Body>
+                <h6 className="mb-3">{row.itemSeq}. {row.itemLabel}</h6>
+
+                <Row className="g-4 align-items-start">
+                  <Col lg={8}>
+                    <Table bordered responsive className="mb-0">
+                      <thead>
+                        <tr>
+                          <th>Instructor score</th>
+                          <th>Student score</th>
+                          <th>Difference</th>
+                          <th>Instructor comment</th>
+                          <th>Student comment</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr>
+                          <td>{scoreLabel(row.instructorScore)}</td>
+                          <td>{scoreLabel(row.studentScore)}</td>
+                          <td>{differenceLabel(row.instructorScore, row.studentScore)}</td>
+                          <td>{commentLabel(row.instructorComment)}</td>
+                          <td>{commentLabel(row.studentComment)}</td>
+                        </tr>
+                      </tbody>
+                    </Table>
+                  </Col>
+
+                  <Col lg={4}>
+                    <div className="d-flex flex-column align-items-center">
+                      <div className="text-muted small mb-2">
+                        Class summary for this rubric ({row.totalResponses} response{row.totalResponses === 1 ? "" : "s"})
+                      </div>
+                      <CalibrationRubricDistributionChart row={row} />
+                      <div className="mt-3 small text-center">
+                        <div>Green Agree: {row.agreeCount}</div>
+                        <div>Yellow Near: {row.nearCount}</div>
+                        <div>Red Disagree: {row.disagreeCount}</div>
+                      </div>
+                    </div>
+                  </Col>
+                </Row>
+              </Card.Body>
+            </Card>
+          ))}
+        </div>
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default CalibrationRubricDetailPanel;

--- a/src/pages/Assignments/components/CalibrationRubricDistributionChart.tsx
+++ b/src/pages/Assignments/components/CalibrationRubricDistributionChart.tsx
@@ -1,0 +1,49 @@
+import { ResponsiveContainer, BarChart, Bar, CartesianGrid, Tooltip, XAxis, YAxis, Cell } from "recharts";
+import type { RubricDetailRow } from "../calibrationReportNormalize";
+
+interface CalibrationRubricDistributionChartProps {
+  row: RubricDetailRow;
+}
+
+const DISTRIBUTION_COLORS = {
+  agree: "#22c55e",
+  near: "#facc15",
+  disagree: "#ef4444",
+};
+
+const CalibrationRubricDistributionChart = ({
+  row,
+}: CalibrationRubricDistributionChartProps) => {
+  const data = [
+    { category: "Agree", count: row.agreeCount, color: DISTRIBUTION_COLORS.agree },
+    { category: "Near", count: row.nearCount, color: DISTRIBUTION_COLORS.near },
+    { category: "Disagree", count: row.disagreeCount, color: DISTRIBUTION_COLORS.disagree },
+  ];
+
+  return (
+    <div style={{ width: 300 }} data-testid={`rubric-distribution-${row.itemId}`}>
+      <div style={{ height: 190 }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart barCategoryGap="22%" barGap={8} data={data} margin={{ top: 8, right: 12, left: 8, bottom: 18 }}>
+            <CartesianGrid strokeDasharray="3 3" vertical={false} />
+            <XAxis
+              dataKey="category"
+              interval={0}
+              tick={{ fontSize: 11 }}
+              tickMargin={10}
+            />
+            <YAxis allowDecimals={false} tick={{ fontSize: 11 }} />
+            <Tooltip formatter={(value: number) => [value, "Responses"]} />
+            <Bar dataKey="count" radius={[6, 6, 0, 0]}>
+              {data.map((entry) => (
+                <Cell key={entry.category} fill={entry.color} />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+};
+
+export default CalibrationRubricDistributionChart;

--- a/src/pages/Assignments/components/CalibrationStackedChart.tsx
+++ b/src/pages/Assignments/components/CalibrationStackedChart.tsx
@@ -3,7 +3,6 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
-  Legend,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -82,7 +81,6 @@ const CalibrationStackedChart = ({
                   }`;
                 }}
               />
-              <Legend formatter={(value) => bucketLabel(value)} />
               {bucketKeys.map((bucketKey) => (
                 <Bar
                   key={bucketKey}

--- a/src/pages/Assignments/components/CalibrationStackedChart.tsx
+++ b/src/pages/Assignments/components/CalibrationStackedChart.tsx
@@ -1,0 +1,156 @@
+import { Card, Table } from "react-bootstrap";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { StackedChartDataRow } from "../calibrationReportNormalize";
+
+interface CalibrationStackedChartProps {
+  bucketKeys: string[];
+  chartData: StackedChartDataRow[];
+}
+
+const AGREEMENT_COLORS: Record<string, string> = {
+  agreeCount: "#22c55e",
+  nearCount: "#facc15",
+  disagreeCount: "#ef4444",
+};
+
+const bucketLabel = (bucketKey: string) => {
+  if (bucketKey === "agreeCount") return "Agree (matches instructor score)";
+  if (bucketKey === "nearCount") return "Near (±1)";
+  return "Disagree";
+};
+
+const CalibrationStackedChart = ({
+  bucketKeys,
+  chartData,
+}: CalibrationStackedChartProps) => {
+  const displayData = chartData.map((row) => ({
+    ...row,
+    distributionSummary: `Agree: ${row.agreeCount}, Near: ${row.nearCount}, Disagree: ${row.disagreeCount}`,
+  }));
+  const chartHeight = Math.max(320, displayData.length * 80);
+
+  return (
+    <Card className="mb-4">
+      <Card.Body>
+        <Card.Title>Class comparison (stacked)</Card.Title>
+        <Card.Text className="text-muted">
+          Each rubric item is shown on the x-axis. The y-axis shows the number of student responses. Green means
+          the student score matches the instructor, yellow means the student is within one point, and red means
+          the student is farther away.
+        </Card.Text>
+
+        <div data-testid="calibration-stacked-chart" style={{ width: "100%", height: chartHeight }}>
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              data={displayData}
+              margin={{ top: 12, right: 24, left: 24, bottom: 12 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis
+                dataKey="itemLabel"
+                interval={0}
+                tick={{ fontSize: 12 }}
+              />
+              <YAxis
+                allowDecimals={false}
+                label={{ value: "Student responses", angle: -90, position: "insideLeft" }}
+              />
+              <Tooltip
+                formatter={(value: number, name: string) => [
+                  value === null ? "N/A" : value,
+                  bucketLabel(name),
+                ]}
+                labelFormatter={(_, payload) => {
+                  const row = payload?.[0]?.payload as StackedChartDataRow | undefined;
+                  if (!row) return "";
+
+                  const displayRow = payload?.[0]?.payload as (StackedChartDataRow & {
+                    distributionSummary?: string;
+                  }) | undefined;
+
+                  return `${row.itemSeq}. ${row.itemLabel}${
+                    displayRow?.distributionSummary ? ` | ${displayRow.distributionSummary}` : ""
+                  }`;
+                }}
+              />
+              <Legend formatter={(value) => bucketLabel(value)} />
+              {bucketKeys.map((bucketKey) => (
+                <Bar
+                  key={bucketKey}
+                  dataKey={bucketKey}
+                  fill={AGREEMENT_COLORS[bucketKey]}
+                  name={bucketKey}
+                  stackId="agreement"
+                  radius={bucketKey === "disagreeCount" ? [6, 6, 0, 0] : [0, 0, 0, 0]}
+                />
+              ))}
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+
+        <div className="d-flex align-items-center gap-2 mb-3">
+          <span
+            style={{
+              width: 14,
+              height: 14,
+              backgroundColor: AGREEMENT_COLORS.agreeCount,
+              display: "inline-block",
+            }}
+          />
+          <span>Agree (matches instructor score)</span>
+          <span
+            style={{
+              width: 14,
+              height: 14,
+              backgroundColor: AGREEMENT_COLORS.nearCount,
+              display: "inline-block",
+              marginLeft: 16,
+            }}
+          />
+          <span>Near (±1)</span>
+          <span
+            style={{
+              width: 14,
+              height: 14,
+              backgroundColor: AGREEMENT_COLORS.disagreeCount,
+              display: "inline-block",
+              marginLeft: 16,
+            }}
+          />
+          <span>Disagree</span>
+        </div>
+
+        <h3 className="h6 mt-4">Instructor reference scores</h3>
+        <Table bordered hover responsive size="sm">
+          <thead>
+            <tr>
+              <th>Criterion</th>
+              <th>Instructor score</th>
+              <th>Student responses</th>
+            </tr>
+          </thead>
+          <tbody>
+            {chartData.map((row) => (
+              <tr key={row.itemId}>
+                <td>{row.itemLabel}</td>
+                <td>{row.instructorScore ?? "N/A"}</td>
+                <td>{row.totalResponses}</td>
+              </tr>
+            ))}
+          </tbody>
+        </Table>
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default CalibrationStackedChart;

--- a/src/pages/Assignments/hooks/useCalibrationInstructorDemo.ts
+++ b/src/pages/Assignments/hooks/useCalibrationInstructorDemo.ts
@@ -1,0 +1,94 @@
+// DEMO_INSTRUCTOR_RESPONSE
+//
+// Demo-only hook: wires the "Begin" button on the Calibration tab to the
+// backend's mock-seeding endpoint. When the instructor clicks "Begin", this
+// hook POSTs to `…/:map_id/mock_instructor_response`, which materialises a
+// submitted instructor calibration Response (and a small set of peer student
+// responses) so the calibration report has data to display.
+//
+// Lives in its own file (and its own Demo-prefixed hook) so:
+//   * AssignmentEditor stays free of mock-data plumbing.
+//   * Deleting the demo is a single file delete + removing the import from
+//     AssignmentEditor and swapping the Begin <button> back to a plain anchor.
+//
+// REMOVAL CHECKLIST when the real instructor-review form ships:
+//   Every line is tagged `DEMO_INSTRUCTOR_RESPONSE` so a repo-wide search
+//   will find them all:
+//
+//     rg DEMO_INSTRUCTOR_RESPONSE
+//
+//   Frontend (this repo):
+//     1. Delete this file (src/pages/Assignments/hooks/useCalibrationInstructorDemo.ts).
+//     2. In AssignmentEditor.tsx:
+//        a. Remove `import useCalibrationInstructorDemo from './hooks/useCalibrationInstructorDemo';`
+//        b. Remove the `const { handleBeginCalibrationReview } = useCalibrationInstructorDemo(...)` call.
+//        c. In the Calibration table's Review column cell, replace the demo <button>:
+//              <button onClick={() => handleBeginCalibrationReview(mapId)}>Begin</button>
+//           with a plain anchor pointing at the real review form:
+//              <a style={linkStyle} href={`${reviewBase}/begin`}>Begin</a>
+//
+//   Backend (reimplementation-back-end-1):
+//     4. Delete app/services/demo/calibration_instructor_seeder.rb.
+//     5. Delete app/controllers/demo/calibration_instructor_responses_controller.rb.
+//     6. Remove the `mock_instructor_response` route from config/routes.rb.
+
+import { useCallback, useEffect } from "react";
+import { useDispatch } from "react-redux";
+import { alertActions } from "../../../store/slices/alertSlice";
+import useAPI from "../../../hooks/useAPI";
+import { HttpMethod } from "../../../utils/httpMethods";
+
+interface UseCalibrationInstructorDemoOptions {
+  assignmentId: number | string | null | undefined;
+  onSuccess: () => void; // called after a successful seed so the table refreshes
+}
+
+export default function useCalibrationInstructorDemo({
+  assignmentId,
+  onSuccess,
+}: UseCalibrationInstructorDemoOptions) {
+  const dispatch = useDispatch();
+  const {
+    data: beginCalibrationResponse,
+    error: beginCalibrationError,
+    sendRequest: sendBeginCalibrationRequest,
+  } = useAPI();
+
+  const handleBeginCalibrationReview = useCallback(
+    (mapId: number | string | null | undefined) => {
+      if (!assignmentId || !mapId) return;
+      sendBeginCalibrationRequest({
+        url: `/assignments/${assignmentId}/review_mappings/${mapId}/mock_instructor_response`,
+        method: HttpMethod.POST,
+      }).catch(() => {
+        // useAPI surfaces the error into beginCalibrationError.
+      });
+    },
+    [assignmentId, sendBeginCalibrationRequest]
+  );
+
+  useEffect(() => {
+    if (
+      beginCalibrationResponse &&
+      beginCalibrationResponse.status >= 200 &&
+      beginCalibrationResponse.status < 300
+    ) {
+      dispatch(
+        alertActions.showAlert({
+          variant: "success",
+          message: "Mock instructor and peer calibration responses submitted",
+        })
+      );
+      onSuccess();
+    }
+  }, [beginCalibrationResponse, dispatch, onSuccess]);
+
+  useEffect(() => {
+    beginCalibrationError &&
+      dispatch(
+        alertActions.showAlert({ variant: "danger", message: beginCalibrationError })
+      );
+  }, [beginCalibrationError, dispatch]);
+
+  return { handleBeginCalibrationReview };
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -25,3 +25,19 @@ Object.defineProperty(window, 'alert', {
   writable: true,
   value: vi.fn(),
 });
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+Object.defineProperty(window, 'ResizeObserver', {
+  writable: true,
+  value: ResizeObserverMock,
+});
+
+Object.defineProperty(globalThis, 'ResizeObserver', {
+  writable: true,
+  value: ResizeObserverMock,
+});


### PR DESCRIPTION
### Calibration tab (assignment editor)
- Search box to add participants by username
- Table with participant name, review status (`Begin` / `View | Edit`), `View review report` link, submitted content (hyperlinks + files), and `Remove` action

### Calibration report page (`CalibrationReview`)
- Fetches report JSON from `GET /assignments/:id/reports/calibration/:map_id`
- **Class comparison tab** — `CalibrationStackedChart` (Recharts stacked bars: agree / near / disagree per rubric item)
- **Rubric detail tab** — `CalibrationRubricDetailPanel`; per-student dropdown; per-item score diff cards with instructor vs student score, comments, and mini class-distribution chart

### Utilities
- `calibrationReportNormalize.ts` — transforms raw report JSON into chart-ready structures

### Code hygiene
- Demo logic extracted into `useCalibrationInstructorDemo` (gitignored), keeping production `AssignmentEditor` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New calibration review page with comparison and rubric-detail tabs, plus a route to access it
  * Calibration tab: backend-driven participant list with add/remove by username, Begin action, and view/edit for completed reviews
  * Visuals: stacked class comparison chart and per-item distribution charts; submitted content links/files shown

* **Tests**
  * Added comprehensive unit and integration tests and test setup to support calibration UI components
<!-- end of auto-generated comment: release notes by coderabbit.ai -->