### PR TITLE
Fix course creation access and improve directory field UX

### DIFF
--- a/src/pages/Courses/Course.tsx
+++ b/src/pages/Courses/Course.tsx
@@ -9,6 +9,7 @@ import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import { alertActions } from "../../store/slices/alertSlice";
 import { RootState } from "../../store/store";
 import { ICourseResponse, ROLE } from "../../utils/interfaces";
+import { hasAllPrivilegesOf } from "../../utils/util";
 import { courseColumns as COURSE_COLUMNS } from "./CourseColumns";
 import CopyCourse from "./CourseCopy";
 import DeleteCourse from "./CourseDelete";
@@ -181,8 +182,7 @@ const renderSubComponent = useCallback(({ row }: { row: TRow<ICourseResponse> })
               </h1>
             </Col>
           </Row>
-          {/* Admin doenot have the option to create a course but he can create an assignment */}
-          {auth.user?.role === ROLE.INSTRUCTOR && (
+          {hasAllPrivilegesOf(auth.user?.role, ROLE.INSTRUCTOR) && (
             <Row>
               <Col md={{ span: 1, offset: 11 }} style={{ paddingBottom: "10px" }}>
                 <Button variant="outline-success" onClick={() => navigate("new")}>

--- a/src/pages/Courses/CourseEditor.tsx
+++ b/src/pages/Courses/CourseEditor.tsx
@@ -156,11 +156,12 @@ useEffect(() => {
           
           
          initialValues={{
+          ...initialValues,
           ...courseData,
-          private: courseData.private || [], // Ensure array default
-          institution_id: courseData.institution_id 
+          private: courseData.private || [],
+          institution_id: courseData.institution_id
             ?? (auth.user?.institution_id ?? initialValues.institution_id),
-          instructor_id: courseData.instructor_id 
+          instructor_id: courseData.instructor_id
             ?? (auth.user?.id ?? initialValues.instructor_id),
         }}
             

--- a/src/pages/Courses/CourseEditor.tsx
+++ b/src/pages/Courses/CourseEditor.tsx
@@ -1,9 +1,9 @@
 import FormCheckBoxGroup from "components/Form/FormCheckBoxGroup";
 import FormInput from "components/Form/FormInput";
 import FormSelect from "components/Form/FormSelect";
-import { Form, Formik, FormikHelpers } from "formik";
+import { Form, Formik, FormikHelpers, useFormikContext } from "formik";
 import useAPI from "../../hooks/useAPI";
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { Button, InputGroup, Modal } from "react-bootstrap";
 import { useDispatch, useSelector } from "react-redux";
 import { useLoaderData, useLocation, useNavigate } from "react-router-dom";
@@ -20,6 +20,35 @@ import { ICourseFormValues, courseVisibility, noSpacesSpecialCharsQuotes, transf
  * @author Harvardhan Patil on Oct, 2024
  */
  
+
+const AutoFillDirectory: React.FC<{ mode: string }> = ({ mode }) => {
+  const { values, setFieldValue } = useFormikContext<ICourseFormValues>();
+  const lastGenerated = useRef('');
+  const directoryRef = useRef(values.directory);
+  directoryRef.current = values.directory;
+
+  useEffect(() => {
+    if (mode !== 'create' || !values.name) return;
+    if (directoryRef.current !== lastGenerated.current) return;
+
+    // Convert name to a path-safe slug: lowercase, non-alphanumeric runs → '_', strip leading/trailing '_'
+    const slug = values.name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '_')
+      .replace(/^_+|_+$/g, '');
+
+    const now = new Date();
+    const month = now.getMonth() + 1;
+    const year = String(now.getFullYear()).slice(-2);
+    const semester = month >= 8 ? `fall${year}` : `spring${year}`;
+
+    const generated = `${slug}/${semester}`;
+    lastGenerated.current = generated;
+    setFieldValue('directory', generated);
+  }, [values.name, mode, setFieldValue]);
+
+  return null;
+};
 
 // Initial form values
 const initialValues: ICourseFormValues = {
@@ -144,6 +173,7 @@ useEffect(() => {
 
             return (
               <Form>
+                <AutoFillDirectory mode={mode} />
                 <FormSelect
                   controlId="course-institution"
                   name="institution_id"
@@ -164,9 +194,8 @@ useEffect(() => {
                   disabled={true}
                   options={
                     users?.data
-                      ?.filter((user: any) => user.role.name === "Instructor")
-                      .map((user: any) => ({
-                        label: user.name,
+                      ?.map((user: any) => ({
+                        label: user.fullName,
                         value: String(user.id),
                       })) || []
                   }
@@ -182,7 +211,7 @@ useEffect(() => {
                 />
                 <FormInput
                   controlId="directory"
-                  label="Course Directory (Mandatory field. No Spaces, Special Characters, or quotes)"
+                  label="Course Directory (Mandatory field. Allowed: letters, digits, underscores, hyphens, slashes)"
                   name="directory"
                 />
                 <FormInput controlId="info" label="Course Information" name="info" />

--- a/src/pages/Courses/CourseEditor.tsx
+++ b/src/pages/Courses/CourseEditor.tsx
@@ -196,7 +196,7 @@ useEffect(() => {
                   options={
                     users?.data
                       ?.map((user: any) => ({
-                        label: user.fullName,
+                        label: user.name,
                         value: String(user.id),
                       })) || []
                   }

--- a/src/pages/Courses/CourseUtil.ts
+++ b/src/pages/Courses/CourseUtil.ts
@@ -148,7 +148,7 @@ export const mergeDataAndNamesAndInstructors = (data: ICourseResponse[], institu
 
     // Find instructor data from instructor id of course
     const matchingInstructor = instructorNames.find((instructorObj) => instructorObj.id === dataObj.instructor_id);
-    const instructorData = matchingInstructor ? { id: matchingInstructor.id, name: matchingInstructor.fullName } : {};
+    const instructorData = matchingInstructor ? { id: matchingInstructor.id, name: matchingInstructor.name } : {};
 
     // Merge course data with institution and instructor data
     return {

--- a/src/pages/Courses/CourseUtil.ts
+++ b/src/pages/Courses/CourseUtil.ts
@@ -122,22 +122,7 @@ export async function loadCourseInstructorDataAndInstitutions({ params }: any) {
 
 // Input Validation for the Directory path of the course
 export const noSpacesSpecialCharsQuotes = (value: string) => {
-  // Check for spaces
-  if (/\s/.test(value)) {
-    return false;
-  }
-
-  // Check for special characters
-  if (/[^a-zA-Z0-9]/.test(value)) {
-    return false;
-  }
-
-  // Check for quotes
-  if (/["']/.test(value)) {
-    return false;
-  }
-
-  return true;
+  return /^[a-zA-Z0-9_/-]+$/.test(value!);
 };
 
 // Function to format the date from ISO to "Dec 4, 2023, 7:35 PM" format.
@@ -163,7 +148,7 @@ export const mergeDataAndNamesAndInstructors = (data: ICourseResponse[], institu
 
     // Find instructor data from instructor id of course
     const matchingInstructor = instructorNames.find((instructorObj) => instructorObj.id === dataObj.instructor_id);
-    const instructorData = matchingInstructor ? { id: matchingInstructor.id, name: matchingInstructor.name } : {};
+    const instructorData = matchingInstructor ? { id: matchingInstructor.id, name: matchingInstructor.fullName } : {};
 
     // Merge course data with institution and instructor data
     return {

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -226,7 +226,7 @@ export interface IInstitutionResponse {
 
 export interface IInstructorResponse {
   id: number;
-  name: string;
+  fullName: string;
 }
 
 export enum ROLE {

--- a/src/utils/interfaces.ts
+++ b/src/utils/interfaces.ts
@@ -226,7 +226,7 @@ export interface IInstitutionResponse {
 
 export interface IInstructorResponse {
   id: number;
-  fullName: string;
+  name: string;
 }
 
 export enum ROLE {


### PR DESCRIPTION
  - Allow Admin and Super Admin to create courses (was restricted to Instructor only)
  - Relax directory path validation to permit underscores, hyphens, and slashes
  - Auto-populate directory field from course name and current semester (e.g. intro_to_cs/fall26); stops auto-filling once user manually edits the field
  - Fix instructor display name to use fullName instead of name